### PR TITLE
log: remove worker context dependency of logs

### DIFF
--- a/src/distributor.h
+++ b/src/distributor.h
@@ -30,14 +30,15 @@
  * provided that can be enabled to preserve packet order.
  */
 
-#define LF_DISTRIBUTOR_LOG(level, ...) \
-	LF_LOG(level, "Distributor: " __VA_ARGS__)
-
 /**
- * Log function for distributor worker.
- * The worker's lcore ID is added to each message.
- * Format (lcore ID 1): "Distributor [1]: log message here"
+ * Log function for distributor.
+ * The lcore ID is added to each message. Format with lcore ID 1:
+ * Distributor [1]: log message here
  */
+#define LF_DISTRIBUTOR_LOG(level, ...)                                      \
+	LF_LOG(level, RTE_FMT("Distributor [%d]: " RTE_FMT_HEAD(__VA_ARGS__, ), \
+						  rte_lcore_id(), RTE_FMT_TAIL(__VA_ARGS__, )))
+
 #define LF_DISTRIBUTOR_LOG_DP(level, ...)                                      \
 	LF_LOG_DP(level, RTE_FMT("Distributor [%d]: " RTE_FMT_HEAD(__VA_ARGS__, ), \
 							 rte_lcore_id(), RTE_FMT_TAIL(__VA_ARGS__, )))

--- a/src/lib/scion/scion.c
+++ b/src/lib/scion/scion.c
@@ -9,26 +9,25 @@
 #include "scion.h"
 
 unsigned int
-scion_skip_gateway_frame_hdr(const struct lf_worker_context *worker_context,
-		const struct rte_mbuf *m, unsigned int offset, uint16_t frame_len,
-		struct rte_ipv4_hdr **enc_ipv4_hdr)
+scion_skip_gateway_frame_hdr(const struct rte_mbuf *m, unsigned int offset,
+		uint16_t frame_len, struct rte_ipv4_hdr **enc_ipv4_hdr)
 {
 	struct scion_gateway_frame_hdr *frame_hdr;
 	struct rte_ipv4_hdr *ipv4_hdr;
 
-	offset = scion_get_gateway_frame_hdr(worker_context, m, offset, &frame_hdr);
+	offset = scion_get_gateway_frame_hdr(m, offset, &frame_hdr);
 	if (offset == 0) {
 		return 0;
 	}
 
 	if (frame_hdr->version != 0) {
-		LF_WORKER_LOG(NOTICE, "Unknown SIG frame header version (%u)\n",
+		LF_WORKER_LOG_DP(NOTICE, "Unknown SIG frame header version (%u)\n",
 				frame_hdr->version);
 		return 0;
 	}
 
 	if (rte_be_to_cpu_16(frame_hdr->index) != 0) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Not yet implemented: SIG frame contains trailing "
 				"part of an IP packet.\n");
 		return 0;
@@ -36,19 +35,19 @@ scion_skip_gateway_frame_hdr(const struct lf_worker_context *worker_context,
 
 	if ((frame_hdr->reserved_stream &
 				rte_cpu_to_be_32(SCION_GATEWAY_FRAME_RSV_MASK)) != 0) {
-		LF_WORKER_LOG(DEBUG,
+		LF_WORKER_LOG_DP(DEBUG,
 				"Unknown SIG frame header reserved fields (%X).\n");
 		return 0;
 	}
 
-	offset = lf_get_ip_hdr(worker_context, m, offset, &ipv4_hdr);
+	offset = lf_get_ip_hdr(m, offset, &ipv4_hdr);
 	if (offset == 0) {
 		return 0;
 	}
 
 	if (frame_len != sizeof(struct scion_gateway_frame_hdr) +
 							 rte_be_to_cpu_16(ipv4_hdr->total_length)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"SIG frame length (%u) does not match SCION/UDP payload length "
 				"(%u). The frame potentially contains multiple IP packets (not "
 				"supported yet).\n",
@@ -63,8 +62,7 @@ scion_skip_gateway_frame_hdr(const struct lf_worker_context *worker_context,
 }
 
 int
-scion_skip_gateway(const struct lf_worker_context *worker_context,
-		uint16_t sig_port, const struct rte_mbuf *m,
+scion_skip_gateway(uint16_t sig_port, const struct rte_mbuf *m,
 		struct rte_ipv4_hdr **enc_ipv4_hdr)
 {
 	unsigned int offset;
@@ -76,77 +74,76 @@ scion_skip_gateway(const struct lf_worker_context *worker_context,
 	uint8_t next_hdr;
 
 	if (unlikely(m->data_len != m->pkt_len)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Not yet implemented: buffer with multiple segments "
 				"received.\n");
 		return -1;
 	}
 
 	offset = 0;
-	offset = lf_get_eth_hdr(worker_context, m, offset, &ether_hdr);
+	offset = lf_get_eth_hdr(m, offset, &ether_hdr);
 	if (unlikely(offset == 0)) {
 		return -1;
 	}
 
 	if (unlikely(ether_hdr->ether_type !=
 				 rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4))) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Unsupported packet type %#X: must be IPv4 (%#X).\n",
 				rte_be_to_cpu_16(ether_hdr->ether_type), RTE_ETHER_TYPE_IPV4);
 		return 0;
 	}
 
-	offset = lf_get_ip_hdr(worker_context, m, offset, &ipv4_hdr);
+	offset = lf_get_ip_hdr(m, offset, &ipv4_hdr);
 	if (unlikely(offset == 0)) {
 		return -1;
 	}
 	if (ipv4_hdr->next_proto_id != IP_PROTO_ID_UDP) {
 		/* Probably intra AS traffic: forward without checks */
 		/* TODO: add flow classification */
-		LF_WORKER_LOG(DEBUG, "IPv4 packet type is not UDP (%#X) but %#X.\n",
+		LF_WORKER_LOG_DP(DEBUG, "IPv4 packet type is not UDP (%#X) but %#X.\n",
 				IP_PROTO_ID_UDP, ipv4_hdr->next_proto_id);
 		return 0;
 	}
 
-	offset = lf_get_udp_hdr(worker_context, m, offset, &udp_hdr);
+	offset = lf_get_udp_hdr(m, offset, &udp_hdr);
 	if (unlikely(offset == 0)) {
 		return -1;
 	}
 	/* TODO: check UDP port is SCION port */
 
-	if (scion_get_cmn_hdr(worker_context, m, offset, &scion_cmn_hdr) == 0) {
+	if (scion_get_cmn_hdr(m, offset, &scion_cmn_hdr) == 0) {
 		return -1;
 	}
 	offset += SCION_HDR_LEN(scion_cmn_hdr);
 	if (unlikely(offset > m->data_len)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Not yet implemented: SCION header exceeds first buffer "
 				"segment.\n");
 		return -1;
 	}
 
-	offset = scion_skip_extension_hdr(worker_context, m, scion_cmn_hdr, offset,
-			&next_hdr);
+	offset = scion_skip_extension_hdr(m, scion_cmn_hdr, offset, &next_hdr);
 	if (offset == 0) {
 		return -1;
 	}
 	if (next_hdr != IPPROTO_UDP) {
-		LF_WORKER_LOG(DEBUG, "SCION packet type is not UDP (%#X) but %#X.\n",
+		LF_WORKER_LOG_DP(DEBUG, "SCION packet type is not UDP (%#X) but %#X.\n",
 				IPPROTO_UDP, next_hdr);
 		return 0;
 	}
 
-	offset = lf_get_udp_hdr(worker_context, m, offset, &scion_udp_hdr);
+	offset = lf_get_udp_hdr(m, offset, &scion_udp_hdr);
 	if (offset == 0) {
 		return -1;
 	}
 	if (rte_be_to_cpu_16(scion_udp_hdr->dst_port) != sig_port) {
-		LF_WORKER_LOG(DEBUG, "SCION UDP port is not SIG port (%u) but %u.\n",
+		LF_WORKER_LOG_DP(DEBUG, "SCION UDP port is not SIG port (%u) but %u.\n",
 				sig_port, rte_be_to_cpu_16(scion_udp_hdr->dst_port));
 		return 0;
 	}
 
-	offset = scion_skip_gateway_frame_hdr(worker_context, m, offset,
+	offset = scion_skip_gateway_frame_hdr(m, offset,
 			rte_be_to_cpu_16(scion_udp_hdr->dgram_len) -
 					sizeof(struct rte_udp_hdr),
 			enc_ipv4_hdr);

--- a/src/lib/utils/packet.h
+++ b/src/lib/utils/packet.h
@@ -33,12 +33,11 @@
 			(((ip) >> 24) & 0xFF)
 
 static inline unsigned int
-lf_get_eth_hdr(const struct lf_worker_context *worker_context,
-		const struct rte_mbuf *m, unsigned int offset,
+lf_get_eth_hdr(const struct rte_mbuf *m, unsigned int offset,
 		struct rte_ether_hdr **ether_hdr_ptr)
 {
 	if (unlikely(sizeof(struct rte_ether_hdr) > m->data_len - offset)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Unsupported packet: Ethernet header exceeds first buffer "
 				"segment.\n");
 		return 0;
@@ -48,7 +47,6 @@ lf_get_eth_hdr(const struct lf_worker_context *worker_context,
 	offset += sizeof(struct rte_ether_hdr);
 
 	return offset;
-	(void)worker_context;
 }
 
 struct lf_ether_hdr_aligned {
@@ -68,12 +66,11 @@ struct lf_ether_hdr_aligned {
 
 
 static inline unsigned int
-lf_get_ipv6_hdr(const struct lf_worker_context *worker_context,
-		const struct rte_mbuf *m, unsigned int offset,
+lf_get_ipv6_hdr(const struct rte_mbuf *m, unsigned int offset,
 		struct rte_ipv6_hdr **ipv6_hdr_ptr)
 {
 	if (unlikely(sizeof(struct rte_ipv6_hdr) > m->data_len - offset)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Unsupported packet: IPv6 header exceeds first buffer "
 				"segment.\n");
 		return 0;
@@ -82,18 +79,16 @@ lf_get_ipv6_hdr(const struct lf_worker_context *worker_context,
 	*ipv6_hdr_ptr = rte_pktmbuf_mtod_offset(m, struct rte_ipv6_hdr *, offset);
 
 	return offset + sizeof(struct rte_ipv6_hdr);
-	(void)worker_context;
 }
 
 static inline unsigned int
-lf_get_ip_hdr(const struct lf_worker_context *worker_context,
-		const struct rte_mbuf *m, unsigned int offset,
+lf_get_ip_hdr(const struct rte_mbuf *m, unsigned int offset,
 		struct rte_ipv4_hdr **ipv4_hdr_ptr)
 {
 	uint16_t ipv4_hdr_length;
 
 	if (unlikely(sizeof(struct rte_ipv4_hdr) > m->data_len - offset)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Unsupported packet: IP header exceeds first buffer "
 				"segment.\n");
 		return 0;
@@ -103,12 +98,12 @@ lf_get_ip_hdr(const struct lf_worker_context *worker_context,
 	ipv4_hdr_length = rte_ipv4_hdr_len(*ipv4_hdr_ptr);
 
 	if (unlikely(ipv4_hdr_length < sizeof(struct rte_ipv4_hdr))) {
-		LF_WORKER_LOG(NOTICE, "Invalid IP header: length too small.\n");
+		LF_WORKER_LOG_DP(NOTICE, "Invalid IP header: length too small.\n");
 		return 0;
 	}
 
 	if (unlikely(ipv4_hdr_length > m->data_len - offset)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Not yet implemented: IP header exceeds first buffer "
 				"segment.\n");
 		return 0;
@@ -117,16 +112,14 @@ lf_get_ip_hdr(const struct lf_worker_context *worker_context,
 	offset += ipv4_hdr_length;
 
 	return offset;
-	(void)worker_context;
 }
 
 static inline unsigned int
-lf_get_udp_hdr(const struct lf_worker_context *worker_context,
-		const struct rte_mbuf *m, unsigned int offset,
+lf_get_udp_hdr(const struct rte_mbuf *m, unsigned int offset,
 		struct rte_udp_hdr **udp_hdr_ptr)
 {
 	if (unlikely(sizeof(struct rte_udp_hdr) > m->data_len - offset)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Not yet implemented: UDP header exceeds first buffer "
 				"segment.\n");
 		return 0;
@@ -135,16 +128,14 @@ lf_get_udp_hdr(const struct lf_worker_context *worker_context,
 	*udp_hdr_ptr = rte_pktmbuf_mtod_offset(m, struct rte_udp_hdr *, offset);
 	offset += sizeof(struct rte_udp_hdr);
 	return offset;
-	(void)worker_context;
 }
 
 static inline unsigned int
-lf_get_tcp_hdr(const struct lf_worker_context *worker_context,
-		const struct rte_mbuf *m, unsigned int offset,
+lf_get_tcp_hdr(const struct rte_mbuf *m, unsigned int offset,
 		struct rte_tcp_hdr **tcp_hdr_ptr)
 {
 	if (unlikely(sizeof(struct rte_tcp_hdr) > m->data_len - offset)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Not yet implemented: TCP header exceeds first buffer "
 				"segment.\n");
 		return 0;
@@ -153,7 +144,6 @@ lf_get_tcp_hdr(const struct lf_worker_context *worker_context,
 	*tcp_hdr_ptr = rte_pktmbuf_mtod_offset(m, struct rte_tcp_hdr *, offset);
 	offset += sizeof(struct rte_tcp_hdr);
 	return offset;
-	(void)worker_context;
 }
 
 /**
@@ -162,8 +152,7 @@ lf_get_tcp_hdr(const struct lf_worker_context *worker_context,
  * offloaded to the port.
  */
 static inline void
-lf_pktv6_set_cksum(const struct lf_worker_context *worker_context,
-		struct rte_mbuf *m, const struct rte_ether_hdr *ether_hdr,
+lf_pktv6_set_cksum(struct rte_mbuf *m, const struct rte_ether_hdr *ether_hdr,
 		struct rte_ipv6_hdr *ipv6_hdr, bool offload_cksum)
 {
 	unsigned int offset = sizeof(*ether_hdr) + sizeof(*ipv6_hdr);
@@ -176,7 +165,7 @@ lf_pktv6_set_cksum(const struct lf_worker_context *worker_context,
 
 		if (ipv6_hdr->proto == IP_PROTO_ID_UDP) {
 			struct rte_udp_hdr *udp_hdr;
-			offset = lf_get_udp_hdr(worker_context, m, offset, &udp_hdr);
+			offset = lf_get_udp_hdr(m, offset, &udp_hdr);
 			if (offset == 0) {
 				return;
 			}
@@ -185,7 +174,7 @@ lf_pktv6_set_cksum(const struct lf_worker_context *worker_context,
 			udp_hdr->dgram_cksum = rte_ipv6_phdr_cksum(ipv6_hdr, m->ol_flags);
 		} else if (ipv6_hdr->proto == IP_PROTO_ID_TCP) {
 			struct rte_tcp_hdr *tcp_hdr;
-			offset = lf_get_tcp_hdr(worker_context, m, offset, &tcp_hdr);
+			offset = lf_get_tcp_hdr(m, offset, &tcp_hdr);
 			if (offset == 0) {
 				return;
 			}
@@ -196,7 +185,7 @@ lf_pktv6_set_cksum(const struct lf_worker_context *worker_context,
 	} else {
 		if (ipv6_hdr->proto == IP_PROTO_ID_UDP) {
 			struct rte_udp_hdr *udp_hdr;
-			offset = lf_get_udp_hdr(worker_context, m, offset, &udp_hdr);
+			offset = lf_get_udp_hdr(m, offset, &udp_hdr);
 			if (offset == 0) {
 				return;
 			}
@@ -204,7 +193,7 @@ lf_pktv6_set_cksum(const struct lf_worker_context *worker_context,
 			udp_hdr->dgram_cksum = rte_ipv6_udptcp_cksum(ipv6_hdr, udp_hdr);
 		} else if (ipv6_hdr->proto == IP_PROTO_ID_TCP) {
 			struct rte_tcp_hdr *tcp_hdr;
-			offset = lf_get_tcp_hdr(worker_context, m, offset, &tcp_hdr);
+			offset = lf_get_tcp_hdr(m, offset, &tcp_hdr);
 			if (offset == 0) {
 				return;
 			}
@@ -220,8 +209,7 @@ lf_pktv6_set_cksum(const struct lf_worker_context *worker_context,
  * offloaded to the port.
  */
 static inline void
-lf_pkt_set_cksum(const struct lf_worker_context *worker_context,
-		struct rte_mbuf *m, const struct rte_ether_hdr *ether_hdr,
+lf_pkt_set_cksum(struct rte_mbuf *m, const struct rte_ether_hdr *ether_hdr,
 		struct rte_ipv4_hdr *ipv4_hdr, bool offload_cksum)
 {
 	unsigned int offset = sizeof(*ether_hdr) + rte_ipv4_hdr_len(ipv4_hdr);
@@ -235,7 +223,7 @@ lf_pkt_set_cksum(const struct lf_worker_context *worker_context,
 
 		if (ipv4_hdr->next_proto_id == IP_PROTO_ID_UDP) {
 			struct rte_udp_hdr *udp_hdr;
-			offset = lf_get_udp_hdr(worker_context, m, offset, &udp_hdr);
+			offset = lf_get_udp_hdr(m, offset, &udp_hdr);
 			if (offset == 0) {
 				return;
 			}
@@ -244,7 +232,7 @@ lf_pkt_set_cksum(const struct lf_worker_context *worker_context,
 			udp_hdr->dgram_cksum = rte_ipv4_phdr_cksum(ipv4_hdr, m->ol_flags);
 		} else if (ipv4_hdr->next_proto_id == IP_PROTO_ID_TCP) {
 			struct rte_tcp_hdr *tcp_hdr;
-			offset = lf_get_tcp_hdr(worker_context, m, offset, &tcp_hdr);
+			offset = lf_get_tcp_hdr(m, offset, &tcp_hdr);
 			if (offset == 0) {
 				return;
 			}
@@ -256,7 +244,7 @@ lf_pkt_set_cksum(const struct lf_worker_context *worker_context,
 		ipv4_hdr->hdr_checksum = 0;
 		if (ipv4_hdr->next_proto_id == IP_PROTO_ID_UDP) {
 			struct rte_udp_hdr *udp_hdr;
-			offset = lf_get_udp_hdr(worker_context, m, offset, &udp_hdr);
+			offset = lf_get_udp_hdr(m, offset, &udp_hdr);
 			if (offset == 0) {
 				return;
 			}
@@ -264,7 +252,7 @@ lf_pkt_set_cksum(const struct lf_worker_context *worker_context,
 			udp_hdr->dgram_cksum = rte_ipv4_udptcp_cksum(ipv4_hdr, udp_hdr);
 		} else if (ipv4_hdr->next_proto_id == IP_PROTO_ID_TCP) {
 			struct rte_tcp_hdr *tcp_hdr;
-			offset = lf_get_tcp_hdr(worker_context, m, offset, &tcp_hdr);
+			offset = lf_get_tcp_hdr(m, offset, &tcp_hdr);
 			if (offset == 0) {
 				return;
 			}
@@ -282,12 +270,11 @@ struct lf_icmpv6_hdr {
 };
 
 static inline unsigned int
-lf_get_icmpv6_hdr(const struct lf_worker_context *worker_context,
-		const struct rte_mbuf *m, unsigned int offset,
+lf_get_icmpv6_hdr(const struct rte_mbuf *m, unsigned int offset,
 		struct lf_icmpv6_hdr **icmpv6_hdr_ptr)
 {
 	if (unlikely(sizeof(struct lf_icmpv6_hdr) > m->data_len - offset)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Unsupported packet: ICMPv6 header exceeds first buffer "
 				"segment.\n");
 		return 0;
@@ -297,7 +284,6 @@ lf_get_icmpv6_hdr(const struct lf_worker_context *worker_context,
 			rte_pktmbuf_mtod_offset(m, struct lf_icmpv6_hdr *, offset);
 
 	return offset + sizeof(struct lf_icmpv6_hdr);
-	(void)worker_context;
 }
 
 #endif /* LF_UTILS_PACKET_H */

--- a/src/mock/worker_fwd.c
+++ b/src/mock/worker_fwd.c
@@ -33,41 +33,41 @@ handle_pkt(struct lf_worker_context *worker_context, struct rte_mbuf *m)
 			worker_context->forwarding_direction;
 
 	if (unlikely(m->data_len != m->pkt_len)) {
-		LF_WORKER_LOG(NOTICE,
+		LF_WORKER_LOG_DP(NOTICE,
 				"Not yet implemented: buffer with multiple segments "
 				"received.\n");
 		return LF_PKT_UNKNOWN_DROP;
 	}
 
 	offset = 0;
-	offset = lf_get_eth_hdr(worker_context, m, offset, &ether_hdr);
+	offset = lf_get_eth_hdr(m, offset, &ether_hdr);
 	if (offset == 0) {
 		return LF_PKT_UNKNOWN_DROP;
 	}
 
 	if (unlikely(ether_hdr->ether_type !=
 				 rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4))) {
-		LF_WORKER_LOG(NOTICE, "Unsupported packet type: must be IPv4.\n");
+		LF_WORKER_LOG_DP(NOTICE, "Unsupported packet type: must be IPv4.\n");
 		return LF_PKT_UNKNOWN_DROP;
 	}
 
-	offset = lf_get_ip_hdr(worker_context, m, offset, &ipv4_hdr);
+	offset = lf_get_ip_hdr(m, offset, &ipv4_hdr);
 	if (offset == 0) {
 		return LF_PKT_UNKNOWN_DROP;
 	}
 
 	if (forwarding_direction == LF_FORWARDING_DIRECTION_INBOUND) {
-		LF_WORKER_LOG(DEBUG, "Inbound packet\n");
+		LF_WORKER_LOG_DP(DEBUG, "Inbound packet\n");
 		pkt_action = LF_PKT_INBOUND_FORWARD;
 
-		(void)lf_worker_pkt_mod(worker_context, m, ether_hdr, ipv4_hdr,
+		(void)lf_worker_pkt_mod(m, ether_hdr, ipv4_hdr,
 				lf_configmanager_worker_get_inbound_pkt_mod(
 						worker_context->config));
 	} else if (forwarding_direction == LF_FORWARDING_DIRECTION_OUTBOUND) {
-		LF_WORKER_LOG(DEBUG, "Outbound packet\n");
+		LF_WORKER_LOG_DP(DEBUG, "Outbound packet\n");
 		pkt_action = LF_PKT_OUTBOUND_FORWARD;
 
-		(void)lf_worker_pkt_mod(worker_context, m, ether_hdr, ipv4_hdr,
+		(void)lf_worker_pkt_mod(m, ether_hdr, ipv4_hdr,
 				lf_configmanager_worker_get_outbound_pkt_mod(
 						worker_context->config));
 
@@ -75,7 +75,7 @@ handle_pkt(struct lf_worker_context *worker_context, struct rte_mbuf *m)
 		/* Consider the packet as inbound if the direction is unknown */
 		pkt_action = LF_PKT_INBOUND_FORWARD;
 
-		(void)lf_worker_pkt_mod(worker_context, m, ether_hdr, ipv4_hdr,
+		(void)lf_worker_pkt_mod(m, ether_hdr, ipv4_hdr,
 				lf_configmanager_worker_get_inbound_pkt_mod(
 						worker_context->config));
 	}

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -11,20 +11,17 @@
 #include "../worker.h"
 
 /**
- * Log function for plugin module (not on data path).
- * Format: "Plugins: log message here"
+ * Log function for LF plugin.
+ * The lcore ID is added to each message. Format with lcore ID 1:
+ * Plugin [1]: log message here
  */
-#define LF_PLUGINS_LOG(level, ...)                                 \
-	LF_LOG(level, RTE_FMT("Plugins: " RTE_FMT_HEAD(__VA_ARGS__, ), \
-						  RTE_FMT_TAIL(__VA_ARGS__, )))
+#define LF_PLUGINS_LOG(level, ...)                                     \
+	LF_LOG(level, RTE_FMT("Plugin [%d]: " RTE_FMT_HEAD(__VA_ARGS__, ), \
+						  rte_lcore_id(), RTE_FMT_TAIL(__VA_ARGS__, )))
 
-/**
- * Data path log function for plugin module.
- * Format: "Plugins: log message here"
- */
 #define LF_PLUGINS_LOG_DP(level, ...)                                     \
-	LF_WORKER_LOG(level, RTE_FMT("Plugins: " RTE_FMT_HEAD(__VA_ARGS__, ), \
-								 RTE_FMT_TAIL(__VA_ARGS__, )))
+	LF_LOG_DP(level, RTE_FMT("Plugin [%d]: " RTE_FMT_HEAD(__VA_ARGS__, ), \
+							 rte_lcore_id(), RTE_FMT_TAIL(__VA_ARGS__, )))
 
 int
 lf_dst_ratelimiter_init(uint16_t nb_workers);

--- a/src/worker.h
+++ b/src/worker.h
@@ -33,12 +33,15 @@
 #endif
 
 /**
- * Log function for workers.
- * Requires the worker context to be implicitly defined as `struct
- * *worker_context`. The worker's ID is then printed in each message. Format
- * (for worker with ID 1): "Worker [1]: log message here"
+ * Log function for LF worker.
+ * The lcore ID is added to each message. Format with lcore ID 1:
+ * Worker [1]: log message here
  */
-#define LF_WORKER_LOG(level, ...)                                         \
+#define LF_WORKER_LOG(level, ...)                                      \
+	LF_LOG(level, RTE_FMT("Worker [%d]: " RTE_FMT_HEAD(__VA_ARGS__, ), \
+						  rte_lcore_id(), RTE_FMT_TAIL(__VA_ARGS__, )))
+
+#define LF_WORKER_LOG_DP(level, ...)                                      \
 	LF_LOG_DP(level, RTE_FMT("Worker [%d]: " RTE_FMT_HEAD(__VA_ARGS__, ), \
 							 rte_lcore_id(), RTE_FMT_TAIL(__VA_ARGS__, )))
 
@@ -199,8 +202,7 @@ lf_worker_check_best_effort_pkt(struct lf_worker_context *worker_context,
  * @param pkt_mod The packet modification configuration.
  */
 void
-lf_worker_pkt_mod(const struct lf_worker_context *worker_context,
-		struct rte_mbuf *m, struct rte_ether_hdr *ether_hdr, void *l3_hdr,
-		const struct lf_config_pkt_mod *pkt_mod);
+lf_worker_pkt_mod(struct rte_mbuf *m, struct rte_ether_hdr *ether_hdr,
+		void *l3_hdr, const struct lf_config_pkt_mod *pkt_mod);
 
 #endif /* LF_WORKER_H */


### PR DESCRIPTION
Logs no longer depend on worker context. The log output now contains the lcore ID.