### PR TITLE
test: archive test artifacts

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -38,7 +38,15 @@ jobs:
           tags: lf-developer:latest
       - name: Start dev container
         run: ./docker.sh dev_create &&./docker.sh dev_up
+      - name: Clear old artifacts
+        run: rm -rf tmp/tests_artifacts
       - name: Run tests in dev container
         run: ./docker.sh dev_exec bash lightning-filter/tests.sh
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: tests-artifacts
+          path: tmp/tests_artifacts
       - name: Stop dev container
         run: ./docker.sh dev_down

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.a
 *.o
 build/
-build_test/
+tmp/
 dependencies/*

--- a/test/testnet_ip/integration_test.sh
+++ b/test/testnet_ip/integration_test.sh
@@ -18,7 +18,7 @@ fi
 
 function cleanup() {
 	# TODO: kill application gracefully
-	sudo tmux kill-session -t $TMUX_SESSION
+	tmux kill-session -t $TMUX_SESSION
 	sleep 0.1
 
 	# tear down test network
@@ -42,7 +42,7 @@ pushd $SCRIPT_DIR > /dev/null
 TMUX_SESSION="lf_session"
 ./testnet.sh up
 sleep 0.1
-sudo tmux new-session -d -s $TMUX_SESSION ./run_lf.sh $lfexec
+tmux new-session -d -s $TMUX_SESSION ./run_lf.sh $lfexec
 sleep 1
 
 # Run tests and count failed tests

--- a/test/testnet_ip/run_lf.sh
+++ b/test/testnet_ip/run_lf.sh
@@ -4,7 +4,8 @@
 
 set -Eeuo pipefail
 
-log_folder="logs/"
+# The log directory is either given as environment variable or defaults to logs/
+log_dir=${LF_LOG_DIR:-"logs/"}
 
 # include network variables
 source "$(dirname "$0")/testnet_vars.sh"
@@ -37,7 +38,7 @@ function lfs_up() {
 	lf_config="config/lf1.json"
 	lcores="(0-5)@0"
 	file_prefix="lf0"
-	log_file="${log_folder}lf0.log"
+	log_file="${log_dir}/lf0.log"
 
 	lf_up
 
@@ -49,7 +50,7 @@ function lfs_up() {
 	lf_config="config/lf2.json"
 	lcores="(0-5)@1"
 	file_prefix="lf1"
-	log_file="${log_folder}lf1.log"
+	log_file="${log_dir}/lf1.log"
 
 	lf_up
 
@@ -93,7 +94,7 @@ fi
 lfexec=$1
 
 # create log folder if not exists
-mkdir -p -- "$log_folder"
+mkdir -p -- "$log_dir"
 
 # execute lightning filter applications
 lfs_up

--- a/test/testnet_scion/README.md
+++ b/test/testnet_scion/README.md
@@ -173,7 +173,7 @@ Note that the SCION configuration is always freshly generated.
 E.g.:
 
 ```
-./integration_test.sh ~/scion/
+./integration_test.sh ../../build/src/lf ~/scion/
 ```
 
 ## Troubleshooting

--- a/test/testnet_scion/integration_test.sh
+++ b/test/testnet_scion/integration_test.sh
@@ -24,7 +24,7 @@ scion_dir=$(realpath $2)
 
 function cleanup() {
 	# TODO: kill application gracefully
-	sudo tmux kill-session -t $TMUX_SESSION
+	tmux kill-session -t $TMUX_SESSION
 	sleep 0.1
 
 	# terminate SCION services
@@ -53,7 +53,7 @@ sleep 0.1
 ./scion/supervisor/supervisor.sh reload
 ./scion/supervisor/supervisor.sh start all
 sleep 1
-sudo tmux new-session -d -s $TMUX_SESSION ./run_lf.sh $lfexec
+tmux new-session -d -s $TMUX_SESSION ./run_lf.sh $lfexec
 sleep 5
 
 # get one SCION ping before doing the tests

--- a/test/testnet_scion/run_lf.sh
+++ b/test/testnet_scion/run_lf.sh
@@ -4,7 +4,8 @@
 
 set -Eeuo pipefail
 
-log_folder="logs/"
+# The log directory is either given as environment variable or defaults to logs/
+log_dir=${LF_LOG_DIR:-"logs/"}
 
 # include network variables
 # source "$(dirname "$0")/testnet_vars.sh"
@@ -35,7 +36,7 @@ function lfs_up() {
 	lf_config="$config_dir/lf_1_ff00_0_111.json"
 	lcores="(0-5)@0"
 	file_prefix="lf0"
-	log_file="${log_folder}lf0.log"
+	log_file="${log_dir}/lf0.log"
 
 	lf_up
 
@@ -47,7 +48,7 @@ function lfs_up() {
 	lf_config="$config_dir/lf_1_ff00_0_112.json"
 	lcores="(0-5)@1"
 	file_prefix="lf1"
-	log_file="${log_folder}lf1.log"
+	log_file="${log_dir}/lf1.log"
 
 	lf_up
 
@@ -95,7 +96,7 @@ lfexec=$1
 config_dir=${2:-config}
 
 # create log folder if not exists
-mkdir -p -- "$log_folder"
+mkdir -p -- "$log_dir"
 
 # execute lightning filter applications
 lfs_up

--- a/tests.sh
+++ b/tests.sh
@@ -2,6 +2,10 @@
 
 set -Euo pipefail
 
+# Move to the script directory.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $SCRIPT_DIR > /dev/null
+
 # Check that SCION_DIR is set.
 # The SCION source directory points to the SCION repository
 # including the SCION binaries in bin/.
@@ -10,27 +14,35 @@ if [ -z "$SCION_DIR" ]; then
     exit -1
 fi
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# Create tmp directory and get absolute path to it.
+TMP_DIR=tmp
+mkdir -p $TMP_DIR
+TMP_DIR=$(cd $TMP_DIR && pwd)
 
-BUILD_DIR=build_test
+
+# Create build directory and get absolute path to it.
+BUILD_DIR=$TMP_DIR/tests_build
+mkdir -p $BUILD_DIR
+BUILD_DIR=$(cd $BUILD_DIR && pwd)
+# Get absolute path to the lf executable.
 LF_EXEC=$BUILD_DIR/src/lf
 
+# Create artifacts directory and get absolute path to it.
+ARTIFACTS_DIR=$TMP_DIR/tests_artifacts
+mkdir -p $ARTIFACTS_DIR
+ARTIFACTS_DIR=$(cd $ARTIFACTS_DIR && pwd)
+
 CURRENT_TIME=$(date "+%Y_%m_%d_%H_%M_%S")
-counter=0
-
-successful=0
-error=0
-
-pushd $SCRIPT_DIR > /dev/null
-
-mkdir $BUILD_DIR
-
-cmake_args=""
 
 function run_integration_test() {
     script=$1
     lf_exec=$2
     args="${@:3}"
+
+    # LF logs should be stored in the artifacts directory.
+    log_dir="${ARTIFACTS_DIR}/${CURRENT_TIME}_${test_label}/lf_logs"
+    mkdir -p $log_dir
+    export LF_LOG_DIR=$log_dir
 
     if (
         $script $lf_exec $args
@@ -46,12 +58,10 @@ function run_integration_test() {
 
 function build_test() {
     pushd $BUILD_DIR > /dev/null
-    mkdir -p Testing/History
-    dir="Testing/History/${CURRENT_TIME}_${counter}"
     rm CMakeCache.txt
 
     if (
-        cmake ../ $cmake_args
+        cmake $SCRIPT_DIR $cmake_args
         make
         make run_tests
     )
@@ -65,15 +75,28 @@ function build_test() {
         ret=1
     fi
 
-    cp -r Testing/Temporary $dir
-    cp CMakeCache.txt "${dir}/"
+    # Copy build artifacts to artifact directory.
+    artifacts_build_dir="${ARTIFACTS_DIR}/${CURRENT_TIME}_${test_label}/build"
+    mkdir -p $artifacts_build_dir
+    cp -r Testing/Temporary $artifacts_build_dir
+    cp CMakeCache.txt "${artifacts_build_dir}/"
 
-    let counter++
     popd > /dev/null
 
     return $ret
 }
 
+function make_artifacts_dir() {
+    artifacts_dir="${ARTIFACTS_DIR}/${CURRENT_TIME}_${test_label}"
+    mkdir -p $artifacts_dir
+}
+
+successful=0
+error=0
+cmake_args=""
+
+test_label="lf_ipv4_drkey_mock"
+make_artifacts_dir
 cmake_args="-D LF_WORKER=IPV4 -D LF_DRKEY_FETCHER=MOCK -D CMAKE_BUILD_TYPE=Release"
 build_test
 if [ $? -eq 0 ]
@@ -81,6 +104,8 @@ then
     run_integration_test test/testnet_ip/integration_test.sh $LF_EXEC
 fi
 
+test_label="lf_fwd"
+make_artifacts_dir
 cmake_args="-D LF_WORKER=FWD -D LF_DRKEY_FETCHER=MOCK -D LF_DISTRIBUTOR=ON"
 build_test
 if [ $? -eq 0 ]
@@ -91,9 +116,13 @@ then
     unset LF_IT_NO_RL
 fi
 
+test_label="lf_fw_plugins"
+make_artifacts_dir
 cmake_args="-D LF_WORKER=IPV4 -D LF_DRKEY_FETCHER=MOCK -D LF_PLUGINS=\"bypass:dst_ratelimiter:wg_ratelimiter\""
 build_test
 
+test_label="lf_scion_drkey_scion"
+make_artifacts_dir
 cmake_args="-D LF_WORKER=SCION -D LF_DRKEY_FETCHER=SCION  -D CMAKE_BUILD_TYPE=Release"
 build_test
 if [ $? -eq 0 ]


### PR DESCRIPTION
The test script `tests.sh` creates the `tmp` directory for the builds, tests, and logs.

Additionally, the CI archives everything that is stored in `tmp/artifacts`.

Fixes #24