### PR TITLE
dpdk: update DPDK version to 23.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(LightningFilter
 
 # DPDK library
 find_package(PkgConfig REQUIRED)
-pkg_search_module(DPDK REQUIRED libdpdk=21.11.0)
+pkg_search_module(DPDK REQUIRED libdpdk=23.11.0)
 
 # OpenSSL library
 set(OPENSSL_USE_STATIC_LIBS TRUE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN curl -LO https://go.dev/dl/go1.17.9.linux-amd64.tar.gz && \
 ENV PATH /usr/local/go/bin:$PATH
 
 # Install DPDK
-RUN curl -LO https://fast.dpdk.org/rel/dpdk-21.11.tar.xz && \
-    echo "58660bbbe9e95abce86e47692b196555 dpdk-21.11.tar.xz" | md5sum -c && \
-    tar xJf dpdk-21.11.tar.xz && cd dpdk-21.11 && \
-    meson build && cd build && ninja && ninja install
+RUN curl -LO https://fast.dpdk.org/rel/dpdk-23.11.tar.xz && \
+    echo "896c09f5b45b452bd77287994650b916 dpdk-23.11.tar.xz" | md5sum -c && \
+    tar xJf dpdk-23.11.tar.xz && cd dpdk-23.11 && \
+    meson setup build && cd build && ninja && meson install && ldconfig
 
 # Allow the lf-build user to use sudo without a password
 RUN groupadd --gid $GID --non-unique $USER && \

--- a/docs/DPDK.md
+++ b/docs/DPDK.md
@@ -1,6 +1,6 @@
 # DPDK Installation, Configuration, and Usage
 
-(Version 21.11)
+(Version 23.11)
 
 ## Installation
 
@@ -21,26 +21,18 @@ sudo apt install python3-pyelftools
 sudo apt install libnuma-dev
 ```
 
-### Get Source
+### Compiling and Installing DPDK System-wide
 
-From archive:
-
-```
-curl -LO https://fast.dpdk.org/rel/dpdk-21.11.tar.xz
-echo "58660bbbe9e95abce86e47692b196555 dpdk-21.11.tar.xz" | md5sum -c
-tar xJf dpdk-21.11.tar.xz
-cd dpdk-21.11
-```
-
-From GitHub:
+Source: [Compiling the DPDK Target from Source](http://doc.dpdk.org/guides-23.11/linux_gsg/build_dpdk.html)
 
 ```
-git clone https://github.com/DPDK/dpdk.git
-cd dpdk
-git checkout v21.11
+curl -LO https://fast.dpdk.org/rel/dpdk-23.11.tar.xz && \
+echo "896c09f5b45b452bd77287994650b916 dpdk-23.11.tar.xz" | md5sum -c && \
+tar xJf dpdk-23.11.tar.xz && cd dpdk-23.11 && \
+meson setup build && cd build && ninja && meson install && ldconfig
 ```
 
-### Configure Build
+#### Configure Build
 
 DPDK uses meson to configure its build.
 
@@ -48,10 +40,10 @@ DPDK uses meson to configure its build.
 meson <options> <build directory>
 ```
 
-E.g., to set the instal directory to `~/dpdk-21.11-inst`:
+E.g., to set the instal directory to `~/dpdk-23.11-inst`:
 
 ```
-meson --prefix ~/dpdk-21.11-inst build
+meson --prefix ~/dpdk-23.11-inst build
 ```
 
 In the build directory, meson can further be used to adjust the build configurations:
@@ -61,20 +53,6 @@ meson configure -D<option>=<value>
 ```
 
 Checkout ``meson configure`` to list the configuration options.
-
-### Build and Install
-
-For building, DPDK uses ninja.
-
-```
-ninja [-C <build directory>]
-```
-
-For installing:
-
-```
-ninja [-C <build directory>] install
-```
 
 ### Linux Drivers
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -5,7 +5,7 @@ For building LightningFilter, we recommended our docker setup (see [Docker](#Doc
 ## Dependencies
 
 Some of the significant dependencies with specific versions required:
-- DPDK 21.11 (see [DPDK.md](DPDK.md))
+- DPDK 23.11 (see [DPDK.md](DPDK.md))
 - OpenSSL Version >= 3.0
 - CMake >= 3.20
 

--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -15,7 +15,7 @@ The LightningFilter help option prints the available parameters:
 ## DPDK EAL Parameters
 
 DPDK documentation: 
-https://doc.dpdk.org/guides-21.11/linux_gsg/linux_eal_parameters.html
+http://doc.dpdk.org/guides-23.11/linux_gsg/linux_eal_parameters.html
 
 ### Lcore-relation option
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,8 +22,7 @@ add_custom_command(TARGET ${EXEC} POST_BUILD
 # Set C standard and compile flags
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)
-# rte_rcu (DPDK v21.11) is not compatible with -pedantic -pedantic-errors
-#add_compile_options(-pedantic --pedantic-errors)
+add_compile_options(-pedantic --pedantic-errors)
 target_compile_options(${EXEC} PRIVATE -O3 -fno-strict-overflow -fno-strict-aliasing)
 target_compile_options(${EXEC} PRIVATE -Wall -Wextra -Werror)
 target_compile_options(${EXEC} PRIVATE -Wcast-qual -Wcast-align -Wunused -Wshadow -Wwrite-strings)
@@ -57,8 +56,8 @@ target_sources(${EXEC} PRIVATE plugins/plugins.c)
 
 # Link DPDK statically
 add_definitions(${DPDK_STATIC_CFLAGS}) # TODO: target
-target_include_directories(${EXEC} PRIVATE ${DPDK_SATIC_INCLUDE_DIRS})
-target_link_libraries(${EXEC} PRIVATE ${DPDK_STATIC_LDFLAGS})
+target_link_libraries(${EXEC} PRIVATE ${DPDK_STATIC_LDFLAGS} ${DPDK_STATIC_LIBS})
+target_include_directories(${EXEC} PRIVATE ${DPDK_STATIC_INCLUDE_DIRS})
 
 # Link OpenSSL
 target_link_libraries(${EXEC} PRIVATE OpenSSL::SSL)

--- a/src/config.h
+++ b/src/config.h
@@ -80,8 +80,6 @@ struct lf_config_pkt_mod {
 #endif
 };
 
-struct lf_config_ratelimiter {};
-
 struct lf_config_dst_ratelimiter {
 	uint32_t dst_ip; /* in network byte order */
 	struct lf_config_ratelimit ratelimit;

--- a/src/keymanager.c
+++ b/src/keymanager.c
@@ -638,8 +638,8 @@ handle_dict_stats(const char *cmd __rte_unused, const char *params __rte_unused,
 	rte_tel_data_start_dict(d);
 
 	rte_spinlock_lock(&tel_ctx->management_lock);
-	rte_tel_data_add_dict_u64(d, "entries", rte_hash_count(tel_ctx->dict));
-	rte_tel_data_add_dict_u64(d, "entries_max",
+	rte_tel_data_add_dict_uint(d, "entries", rte_hash_count(tel_ctx->dict));
+	rte_tel_data_add_dict_uint(d, "entries_max",
 			rte_hash_max_key_id(tel_ctx->dict));
 
 	rte_spinlock_lock(&tel_ctx->management_lock);
@@ -657,7 +657,7 @@ handle_stats(const char *cmd __rte_unused, const char *params __rte_unused,
 	rte_tel_data_start_dict(d);
 	values = (uint64_t *)&tel_ctx->statistics;
 	for (i = 0; i < LF_KEYMANAGER_STATISTICS_NUM; i++) {
-		rte_tel_data_add_dict_u64(d, lf_keymanager_statistics_strings[i].name,
+		rte_tel_data_add_dict_uint(d, lf_keymanager_statistics_strings[i].name,
 				values[i]);
 	}
 

--- a/src/keymanager.c
+++ b/src/keymanager.c
@@ -534,6 +534,8 @@ lf_keymanager_init(struct lf_keymanager *km, uint16_t nb_workers,
 	km->qsv = qsv;
 	km->nb_workers = nb_workers;
 
+	rte_spinlock_init(&km->management_lock);
+
 	/* dictionary requires a size of at least 8 (magic number) */
 	// NOLINTBEGIN(readability-magic-numbers)
 	if (initial_size < 8) {

--- a/src/lib/aesni/test/aesni_test.c
+++ b/src/lib/aesni/test/aesni_test.c
@@ -86,7 +86,7 @@ main(int argc, char *argv[])
 
 	// parse key
 	unsigned char *key = calloc(16, sizeof(unsigned char));
-	int tmp; // to hold byte values
+	unsigned int tmp; // to hold byte values
 
 	for (int i = 0; i < 16; i++) {
 		tmp = 0;

--- a/src/lib/crypto/crypto.h
+++ b/src/lib/crypto/crypto.h
@@ -25,6 +25,8 @@
  */
 struct lf_crypto_drkey_ctx {
 #ifdef LF_CBCMAC_AESNI
+	/* field to avoid empty struct */
+	uint8_t dummy;
 #else
 	EVP_CIPHER_CTX *mdctx;
 #endif

--- a/src/lib/crypto/test/crypto_mac.c
+++ b/src/lib/crypto/test/crypto_mac.c
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
 	// parse key
 	uint8_t key_buf[16];
 	struct lf_crypto_drkey drkey;
-	int tmp; // to hold byte values
+	unsigned int tmp; // to hold byte values
 
 	for (int i = 0; i < 16; i++) {
 		tmp = 0;

--- a/src/lib/mirror/mirror.c
+++ b/src/lib/mirror/mirror.c
@@ -23,7 +23,6 @@ static uint16_t nb_txd = 512;
 
 static const struct rte_eth_conf mirror_port_conf = {
 	.rxmode = {
-		.split_hdr_size = 0,
 		/* TODO: make mtu configurable on the mirror. */
 		.mtu = 1500,
 	},
@@ -154,7 +153,7 @@ configure_port(uint16_t port_id, uint16_t nb_queues,
 				local_port_conf.rx_adv_conf.rss_conf.rss_hf);
 		if (local_port_conf.rx_adv_conf.rss_conf.rss_hf == 0) {
 			LF_LOG(WARNING, "Port %u does not use RSS!\n", port_id);
-			local_port_conf.rxmode.mq_mode = ETH_MQ_RX_NONE;
+			local_port_conf.rxmode.mq_mode = RTE_ETH_MQ_RX_NONE;
 		}
 	}
 

--- a/src/setup.c
+++ b/src/setup.c
@@ -50,23 +50,22 @@ struct port_queues_conf {
 
 static const struct rte_eth_conf global_port_conf = {
 	.rxmode = {
-		.split_hdr_size = 0,
 		.mq_mode = RTE_ETH_MQ_RX_RSS,
 	},
 	.rx_adv_conf = {
 		.rss_conf = {
 			.rss_key = NULL,
-			.rss_hf = ETH_RSS_FRAG_IPV4
-				| ETH_RSS_NONFRAG_IPV4_TCP
-				| ETH_RSS_NONFRAG_IPV4_UDP
-				| ETH_RSS_NONFRAG_IPV4_SCTP
-				| ETH_RSS_NONFRAG_IPV4_OTHER
-				| ETH_RSS_FRAG_IPV6
-				| ETH_RSS_NONFRAG_IPV6_TCP
-				| ETH_RSS_NONFRAG_IPV6_UDP
-				| ETH_RSS_NONFRAG_IPV6_SCTP
-				| ETH_RSS_NONFRAG_IPV6_OTHER
-				| ETH_RSS_L2_PAYLOAD,
+			.rss_hf = RTE_ETH_RSS_FRAG_IPV4
+				| RTE_ETH_RSS_NONFRAG_IPV4_TCP
+				| RTE_ETH_RSS_NONFRAG_IPV4_UDP
+				| RTE_ETH_RSS_NONFRAG_IPV4_SCTP
+				| RTE_ETH_RSS_NONFRAG_IPV4_OTHER
+				| RTE_ETH_RSS_FRAG_IPV6
+				| RTE_ETH_RSS_NONFRAG_IPV6_TCP
+				| RTE_ETH_RSS_NONFRAG_IPV6_UDP
+				| RTE_ETH_RSS_NONFRAG_IPV6_SCTP
+				| RTE_ETH_RSS_NONFRAG_IPV6_OTHER
+				| RTE_ETH_RSS_L2_PAYLOAD,
 		},
 	},
 	.txmode = {
@@ -253,7 +252,7 @@ port_init(uint16_t port_id, struct port_queues_conf *port_conf,
 				local_port_conf.rx_adv_conf.rss_conf.rss_hf);
 		if (local_port_conf.rx_adv_conf.rss_conf.rss_hf == 0) {
 			LF_LOG(WARNING, "Port %u does not use RSS!\n", port_id);
-			local_port_conf.rxmode.mq_mode = ETH_MQ_RX_NONE;
+			local_port_conf.rxmode.mq_mode = RTE_ETH_MQ_RX_NONE;
 		}
 	}
 
@@ -411,7 +410,7 @@ check_all_ports_link_status(uint32_t port_mask)
 				continue;
 			}
 			/* clear all_ports_up flag if any link down */
-			if (link.link_status == ETH_LINK_DOWN) {
+			if (link.link_status == RTE_ETH_LINK_DOWN) {
 				all_ports_up = 0;
 				break;
 			}

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -184,7 +184,7 @@ handle_worker_stats(const char *cmd __rte_unused, const char *params,
 		aggregate_worker_statistics(telemetry_ctx);
 		values = (uint64_t *)&telemetry_ctx->aggregate_worker[worker_id];
 		for (i = 0; i < WORKER_COUNTER_NUM; i++) {
-			rte_tel_data_add_dict_u64(d, worker_counter_strings[i].name,
+			rte_tel_data_add_dict_uint(d, worker_counter_strings[i].name,
 					values[i]);
 		}
 		rte_spinlock_unlock(&telemetry_ctx->lock);
@@ -193,7 +193,7 @@ handle_worker_stats(const char *cmd __rte_unused, const char *params,
 		aggregate_worker_statistics(telemetry_ctx);
 		values = (uint64_t *)&telemetry_ctx->aggregate_global;
 		for (i = 0; i < WORKER_COUNTER_NUM; i++) {
-			rte_tel_data_add_dict_u64(d, worker_counter_strings[i].name,
+			rte_tel_data_add_dict_uint(d, worker_counter_strings[i].name,
 					values[i]);
 		}
 		(void)rte_spinlock_unlock(&telemetry_ctx->lock);

--- a/src/test/config_parser_test.c
+++ b/src/test/config_parser_test.c
@@ -294,12 +294,9 @@ check_modifier(struct lf_config_pkt_mod *pmod,
 }
 
 int
-check_ratelimiter(struct lf_config_ratelimiter *config,
-		struct lf_config_ratelimiter *config_exp)
+check_ratelimiter()
 {
 	int error_count = 0;
-	(void)config;
-	(void)config_exp;
 	return error_count;
 }
 

--- a/usertools/install_deps.sh
+++ b/usertools/install_deps.sh
@@ -42,19 +42,19 @@ pushd $DEP_DIR
 ## Install required tools and libraries
 sudo apt -y install build-essential meson ninja-build python3-pyelftools libnuma-dev
 ## Get source
-curl -LO https://fast.dpdk.org/rel/dpdk-21.11.tar.xz
-echo "58660bbbe9e95abce86e47692b196555 dpdk-21.11.tar.xz" | md5sum -c
-tar xJf dpdk-21.11.tar.xz
-pushd dpdk-21.11
+curl -LO https://fast.dpdk.org/rel/dpdk-23.11.tar.xz
+echo "896c09f5b45b452bd77287994650b916 dpdk-23.11.tar.xz" | md5sum -c
+tar xJf dpdk-23.11.tar.xz
+pushd dpdk-23.11
 ## Build and Install DPDK
-meson --prefix $DEP_DIR/dpdk-21.11-inst build
+meson --prefix $DEP_DIR/dpdk-23.11-inst build
 pushd build
 ninja
 ninja install
 # Add to pkg-config PATH
 echo >> $ENV_VARS_FILE
 echo "# set PKG_CONFIG_PATH so it includes DPDK pkg-config" >> $ENV_VARS_FILE
-echo "export PKG_CONFIG_PATH=\$PKG_CONFIG_PATH:$DEP_DIR/dpdk-21.11-inst/lib/x86_64-linux-gnu/pkgconfig/" >> $ENV_VARS_FILE
+echo "export PKG_CONFIG_PATH=\$PKG_CONFIG_PATH:$DEP_DIR/dpdk-23.11-inst/lib/x86_64-linux-gnu/pkgconfig/" >> $ENV_VARS_FILE
 ## Return to working directory
 popd && popd && popd
 
@@ -79,5 +79,5 @@ popd
 # Set environmental variables for GitHub Actions
 if [ -n "$GITHUB_ENV" ]; then
     echo "$DEP_DIR/go/bin" >> $GITHUB_PATH
-    echo "PKG_CONFIG_PATH=$DEP_DIR/dpdk-21.11-inst/lib/x86_64-linux-gnu/pkgconfig/" >> $GITHUB_ENV
+    echo "PKG_CONFIG_PATH=$DEP_DIR/dpdk-23.11-inst/lib/x86_64-linux-gnu/pkgconfig/" >> $GITHUB_ENV
 fi


### PR DESCRIPTION
Update to the newest LTS DPDK version, 23.11.

Fixes #32

Furthermore:
- enable pedantic compile flag
- fix keymanager spinlock initialization

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lightning-filter/33)
<!-- Reviewable:end -->
