### PR TITLE
configmanager: simplify config setting

### DIFF
--- a/src/configmanager.c
+++ b/src/configmanager.c
@@ -34,38 +34,64 @@
 	LF_LOG(level, "Config Manager: " __VA_ARGS__)
 
 /**
- * Set the new configuration for the manager and all workers.
- * @return struct lf_config* Returns the old configuration struct, which can be
- * freed by the caller.
+ * Set the new configuration for all workers.
  */
-struct lf_config *
-set_config(struct lf_configmanager *cm, struct lf_config *new_config)
+void
+update_worker_config(struct lf_configmanager *cm, struct lf_config *new_config)
 {
 	size_t i;
-	struct lf_config *old_config;
-	old_config = cm->config;
-	cm->config = new_config;
-
-	rte_spinlock_lock(&cm->manager_lock);
-	LF_CONFIGMANAGER_LOG(NOTICE, "Set config...\n");
-
 	/* set config for workers */
 	for (i = 0; i < cm->nb_workers; ++i) {
 		atomic_store_explicit(&cm->workers[i].config, cm->config,
 				memory_order_relaxed);
 	}
-
 	rte_rcu_qsbr_synchronize(cm->qsv, RTE_QSBR_THRID_INVALID);
-
-	rte_spinlock_unlock(&cm->manager_lock);
-
-	LF_CONFIGMANAGER_LOG(NOTICE, "Set config successfully\n");
-
-	return old_config;
+	return;
 }
 
 int
-lf_configmanager_load_config(struct lf_configmanager *cm,
+lf_configmanager_apply_config(struct lf_configmanager *cm,
+		struct lf_config *new_config)
+{
+	int res = 0;
+	struct lf_config *old_config;
+
+	rte_spinlock_lock(&cm->manager_lock);
+	LF_CONFIGMANAGER_LOG(NOTICE, "Set config...\n");
+
+	/* replace stored config */
+	old_config = cm->config;
+	cm->config = new_config;
+
+	/* update service's config */
+	if (cm->rl != NULL) {
+		res = lf_ratelimiter_apply_config(cm->rl, new_config);
+	}
+	if (cm->km != NULL) {
+		res |= lf_keymanager_apply_config(cm->km, new_config);
+	}
+	res |= lf_plugins_apply_config(new_config);
+
+	/* update worker's config */
+	update_worker_config(cm, new_config);
+
+	if (old_config != NULL) {
+		lf_config_free(old_config);
+	}
+
+	if (res == 0) {
+		LF_CONFIGMANAGER_LOG(NOTICE, "Set config successfully\n");
+	} else {
+		LF_CONFIGMANAGER_LOG(ERR, "Failed applying config\n");
+	}
+
+	rte_spinlock_unlock(&cm->manager_lock);
+
+	return res;
+}
+
+int
+lf_configmanager_apply_config_file(struct lf_configmanager *cm,
 		const char *config_path)
 {
 	struct lf_config *config;
@@ -77,17 +103,13 @@ lf_configmanager_load_config(struct lf_configmanager *cm,
 		return -1;
 	}
 
-	config = set_config(cm, config);
-	if (config != NULL) {
-		lf_config_free(config);
-	}
-
-	return 0;
+	return lf_configmanager_apply_config(cm, config);
 }
 
 int
 lf_configmanager_init(struct lf_configmanager *cm, uint16_t nb_workers,
-		struct rte_rcu_qsbr *qsv)
+		struct rte_rcu_qsbr *qsv, struct lf_keymanager *km,
+		struct lf_ratelimiter *rl)
 {
 	uint16_t worker_id;
 
@@ -107,6 +129,9 @@ lf_configmanager_init(struct lf_configmanager *cm, uint16_t nb_workers,
 		cm->workers[worker_id].config = cm->config;
 	}
 
+	cm->km = km;
+	cm->rl = rl;
+
 	return 0;
 }
 
@@ -116,65 +141,24 @@ lf_configmanager_init(struct lf_configmanager *cm, uint16_t nb_workers,
 
 /* Global config manager context */
 static struct lf_configmanager *cm_ctx = NULL;
-static struct lf_ratelimiter *ipc_ratelimiter = NULL;
-static struct lf_keymanager *ipc_keymanager = NULL;
 
 int
 ipc_global_config(const char *cmd __rte_unused, const char *p, char *out_buf,
 		size_t buf_len)
 {
 	int res = 0;
-	struct lf_config *config;
-
-	LF_LOG(INFO, "Load config from %s ...\n", p);
-	config = lf_config_new_from_file(p);
-	if (config == NULL) {
-		LF_LOG(ERR, "Config parser failed\n");
-		return -1;
-	}
-
-	if (ipc_ratelimiter != NULL) {
-		res = lf_ratelimiter_apply_config(ipc_ratelimiter, config);
-	}
-	if (ipc_keymanager != NULL) {
-		res |= lf_keymanager_apply_config(ipc_keymanager, config);
-	}
-	res |= lf_plugins_apply_config(config);
-
-	config = set_config(cm_ctx, config);
-	if (config != NULL) {
-		lf_config_free(config);
-	}
-
+	res = lf_configmanager_apply_config_file(cm_ctx, p);
 	if (res != 0) {
-		return -1;
+		return snprintf(out_buf, buf_len, "An error ocurred");
 	}
-
 	return snprintf(out_buf, buf_len, "successfully applied config");
 }
 
 int
-ipc_traffic_config(const char *cmd __rte_unused, const char *params,
-		char *out_buf, size_t buf_len)
-{
-	if (params != NULL) {
-		if (lf_configmanager_load_config(cm_ctx, params)) {
-			return snprintf(out_buf, buf_len, "An error ocurred");
-		}
-		return snprintf(out_buf, buf_len, "Loaded config from %s.", params);
-	} else {
-		return snprintf(out_buf, buf_len, "File path is missing.");
-	}
-}
-
-int
-lf_configmanager_register_ipc(struct lf_configmanager *cm,
-		struct lf_keymanager *km, struct lf_ratelimiter *rl)
+lf_configmanager_register_ipc(struct lf_configmanager *cm)
 {
 	int res;
 
-	res = lf_ipc_register_cmd("/traffic/config", ipc_traffic_config,
-			"Load traffic config from file");
 	res |= lf_ipc_register_cmd("/config", ipc_global_config,
 			"Load global config, i.e., config for all modules, from file");
 	if (res != 0) {
@@ -184,8 +168,6 @@ lf_configmanager_register_ipc(struct lf_configmanager *cm,
 
 	/* set ipc contexts */
 	cm_ctx = cm;
-	ipc_ratelimiter = rl;
-	ipc_keymanager = km;
 
 	return 0;
 }

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -46,6 +46,10 @@ struct lf_configmanager {
 	/* Lock to synchronize any manager actions, such as changing the current
 	 * configuration */
 	rte_spinlock_t manager_lock;
+
+	/* Reference to other services which are notified on config change. */
+	struct lf_keymanager *km;
+	struct lf_ratelimiter *rl;
 };
 
 /**
@@ -53,7 +57,8 @@ struct lf_configmanager {
  */
 int
 lf_configmanager_init(struct lf_configmanager *cm, uint16_t nb_workers,
-		struct rte_rcu_qsbr *qsv);
+		struct rte_rcu_qsbr *qsv, struct lf_keymanager *km,
+		struct lf_ratelimiter *rl);
 
 /**
  * Load new config from json file.
@@ -62,7 +67,7 @@ lf_configmanager_init(struct lf_configmanager *cm, uint16_t nb_workers,
  * @return Returns 0 on success.
  */
 int
-lf_configmanager_load_config(struct lf_configmanager *cm,
+lf_configmanager_apply_config_file(struct lf_configmanager *cm,
 		const char *config_path);
 
 /**
@@ -72,8 +77,7 @@ lf_configmanager_load_config(struct lf_configmanager *cm,
  * @return Returns 0 on success.
  */
 int
-lf_configmanager_register_ipc(struct lf_configmanager *cm,
-		struct lf_keymanager *km, struct lf_ratelimiter *rl);
+lf_configmanager_register_ipc(struct lf_configmanager *cm);
 
 /**
  * Get outbound DRKey protocol (network byte order).

--- a/src/keymanager.c
+++ b/src/keymanager.c
@@ -581,7 +581,6 @@ static struct lf_keymanager *ipc_ctx;
 int
 lf_keymanager_register_ipc(struct lf_keymanager *km)
 {
-	int res;
 	ipc_ctx = km;
 
 	/* TODO: add command to add/remove peer */

--- a/src/keymanager.c
+++ b/src/keymanager.c
@@ -578,42 +578,13 @@ lf_keymanager_init(struct lf_keymanager *km, uint16_t nb_workers,
 /* Keymanager context used when IPC commands are processed. */
 static struct lf_keymanager *ipc_ctx;
 
-static int
-ipc_config_load(const char *cmd __rte_unused, const char *p, char *out_buf,
-		size_t buf_len)
-{
-	int res;
-	struct lf_config *config;
-
-	LF_KEYMANAGER_LOG(INFO, "Load config from %s ...\n", p);
-	config = lf_config_new_from_file(p);
-	if (config == NULL) {
-		LF_LOG(ERR, "Config parser failed\n");
-		return -1;
-	}
-
-	res = lf_keymanager_apply_config(ipc_ctx, config);
-	lf_config_free(config);
-
-	if (res != 0) {
-		return -1;
-	}
-
-	return snprintf(out_buf, buf_len, "successfully applied config");
-}
-
 int
 lf_keymanager_register_ipc(struct lf_keymanager *km)
 {
 	int res;
 	ipc_ctx = km;
 
-	res = lf_ipc_register_cmd("/keymanager/config", ipc_config_load,
-			"Load key manager config file. "
-			"parameter: <config file>");
-	if (res != 0) {
-		return -1;
-	}
+	/* TODO: add command to add/remove peer */
 
 	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -299,7 +299,6 @@ main(int argc, char **argv)
 	int res;
 	uint16_t lcore_id, worker_id, worker_counter;
 	struct lf_params params;
-	struct lf_config *global_config, *config;
 	struct lf_ratelimiter_worker *ratelimiter_workers[RTE_MAX_LCORE];
 
 	/* Worker RCU QS Variable */
@@ -332,19 +331,6 @@ main(int argc, char **argv)
 	res = lf_params_parse(argc, argv, &params);
 	if (res < 0) {
 		rte_exit(EXIT_FAILURE, "Invalid application parameters\n");
-	}
-
-	/*
-	 * Load Global Config
-	 */
-	if (params.config_file[0] != '\0') {
-		global_config = lf_config_new_from_file(params.config_file);
-		if (global_config == NULL) {
-			rte_exit(EXIT_FAILURE, "Failed to load config file %s\n",
-					params.config_file);
-		}
-	} else {
-		global_config = NULL;
 	}
 
 	/*

--- a/src/params.c
+++ b/src/params.c
@@ -40,11 +40,9 @@ static const struct lf_params default_params = {
 	.bf_bytes = 131072, /* 2^20 / 8 */
 
 	/* ratelimiter */
-	.rl_config_file = "",
 	.rl_size = 1024,
 
 	/* keymanager */
-	.km_config_file = "",
 	.km_size = 1024,
 };
 
@@ -74,9 +72,7 @@ static const char short_options[] = "v:" /* version */
 #define CMD_LINE_OPT_BF_PERIOD       "bf-period"
 #define CMD_LINE_OPT_BF_HASHES       "bf-hashes"
 #define CMD_LINE_OPT_BF_BYTES        "bf-bytes"
-#define CMD_LINE_OPT_RL_CONFIG_FILE  "rl-config-file"
 #define CMD_LINE_OPT_RL_SIZE         "rl-size"
-#define CMD_LINE_OPT_KM_CONFIG_FILE  "km-config-file"
 #define CMD_LINE_OPT_KM_SIZE         "km-size"
 #define CMD_LINE_OPT_DISABLE_MIRRORS "disable-mirrors"
 
@@ -120,11 +116,7 @@ static const struct option long_options[] = {
 	{ CMD_LINE_OPT_BF_HASHES, required_argument, 0,
 			CMD_LINE_OPT_BF_HASHES_NUM },
 	{ CMD_LINE_OPT_BF_BYTES, required_argument, 0, CMD_LINE_OPT_BF_BYTES_NUM },
-	{ CMD_LINE_OPT_RL_CONFIG_FILE, required_argument, 0,
-			CMD_LINE_OPT_RL_CONFIG_FILE_NUM },
 	{ CMD_LINE_OPT_RL_SIZE, required_argument, 0, CMD_LINE_OPT_RL_SIZE_NUM },
-	{ CMD_LINE_OPT_KM_CONFIG_FILE, required_argument, 0,
-			CMD_LINE_OPT_KM_CONFIG_FILE_NUM },
 	{ CMD_LINE_OPT_KM_SIZE, required_argument, 0, CMD_LINE_OPT_KM_SIZE_NUM },
 	{ CMD_LINE_OPT_DISABLE_MIRRORS, no_argument, 0,
 			CMD_LINE_OPT_DISABLE_MIRRORS_NUM },
@@ -166,12 +158,8 @@ lf_usage(const char *prgname)
 			"  --bf-bytes=NUM\n"
 			"         Size of each Bloom filter bit arrays in bytes\n"
 			"         Must be a power of 2 and at least 8\n"
-			"  --rl-config-file=CONFIG_FILE\n"
-			"         configuration file to be loaded for the ratelimiter\n"
 			"  --rl-size=NUM\n"
 			"         Size of ratelimiter hash table.\n"
-			"  --km-config-file=CONFIG_FILE\n"
-			"         configuration file to be loaded for the keymanager\n"
 			"  --km-size=NUM\n"
 			"         Size of keymanager hash table.\n"
 			"  --disable-mirrors\n"
@@ -516,28 +504,12 @@ lf_params_parse(int argc, char **argv, struct lf_params *params)
 				return -1;
 			}
 			break;
-		/* config file */
-		case CMD_LINE_OPT_RL_CONFIG_FILE_NUM:
-			if (strlen(optarg) > PATH_MAX || strlen(optarg) == 0) {
-				LF_LOG(ERR, "Invalid ratelimiter config file name\n");
-				return -1;
-			}
-			(void)strcpy(params->rl_config_file, optarg);
-			break;
 		case CMD_LINE_OPT_RL_SIZE_NUM:
 			res = parse_uint(optarg, &params->rl_size);
 			if (res != 0 || params->rl_size == 0) {
 				LF_LOG(ERR, "Invalid rl-size\n");
 				return -1;
 			}
-			break;
-		/* config file */
-		case CMD_LINE_OPT_KM_CONFIG_FILE_NUM:
-			if (strlen(optarg) > PATH_MAX || strlen(optarg) == 0) {
-				LF_LOG(ERR, "Invalid keymanager config file name\n");
-				return -1;
-			}
-			(void)strcpy(params->km_config_file, optarg);
 			break;
 		case CMD_LINE_OPT_KM_SIZE_NUM:
 			res = parse_uint(optarg, &params->km_size);

--- a/src/params.h
+++ b/src/params.h
@@ -60,13 +60,11 @@ struct lf_params {
 	/*
 	 * Rate Limiter
 	 */
-	char rl_config_file[PATH_MAX];
 	unsigned int rl_size;
 
 	/*
 	 * Keymanager
 	 */
-	char km_config_file[PATH_MAX];
 	unsigned int km_size;
 };
 

--- a/src/ratelimiter.c
+++ b/src/ratelimiter.c
@@ -593,30 +593,6 @@ ipc_ratelimit_set(const char *cmd __rte_unused, const char *p, char *out_buf,
 	}
 }
 
-static int
-ipc_config_load(const char *cmd __rte_unused, const char *p, char *out_buf,
-		size_t buf_len)
-{
-	int res;
-	struct lf_config *config;
-
-	LF_RATELIMITER_LOG(INFO, "Load config from %s ...\n", p);
-	config = lf_config_new_from_file(p);
-	if (config == NULL) {
-		LF_LOG(ERR, "Config parser failed\n");
-		return -1;
-	}
-
-	res = lf_ratelimiter_apply_config(rl_ctx, config);
-	lf_config_free(config);
-
-	if (res != 0) {
-		return -1;
-	}
-
-	return snprintf(out_buf, buf_len, "successfully applied config");
-}
-
 int
 lf_ratelimiter_register_ipc(struct lf_ratelimiter *rl)
 {
@@ -627,17 +603,13 @@ lf_ratelimiter_register_ipc(struct lf_ratelimiter *rl)
 	 */
 	res = lf_ipc_register_cmd("/ratelimiter/set", ipc_ratelimit_set,
 			"Set rate limit.\n"
+			"Please note that the set value is not persistent "
+			"and will be overridden when updating the configuration.\n"
 			"parameter (peer): <AS>,<DRKey-Proto>,<rate>\n"
 			"parameter (overall): -,-,<rate>\n"
 			"parameter (auth peers): *,*,<rate>\n"
 			"parameter (best-effort): ?,?,<rate>\n"
 			"rate: <byte_rate>,<byte_burst>,<pkt_rate>,<pkt_burst>");
-	if (res != 0) {
-		return -1;
-	}
-	res = lf_ipc_register_cmd("/ratelimiter/config", ipc_config_load,
-			"Load rate limits from config file. "
-			"parameter: <config file>");
 	if (res != 0) {
 		return -1;
 	}


### PR DESCRIPTION
Simplify the setting of the configuration. Remove the parameter options and RPC commands to set the config for keymanager and ratelimiter separately because it was not used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lightning-filter/35)
<!-- Reviewable:end -->
