### PR TITLE
correct time conversion constants

### DIFF
--- a/src/lib/time/time.h
+++ b/src/lib/time/time.h
@@ -15,9 +15,9 @@
 #define LF_TIME_WORKER_UPDATE_INTERVAL 0.1 /* Seconds */
 
 static const uint64_t LF_TIME_NS_IN_S =
-		(uint64_t)10e9; /* nanoseconds in seconds */
+		(uint64_t)1e9; /* nanoseconds in seconds */
 static const uint64_t LF_TIME_NS_IN_MS =
-		(uint64_t)10e6; /* nanoseconds in milliseconds */
+		(uint64_t)1e6; /* nanoseconds in milliseconds */
 
 struct lf_time_worker {
 	/* current cached time value */

--- a/src/test/keymanager_test.c
+++ b/src/test/keymanager_test.c
@@ -168,7 +168,7 @@ test1()
 			&src_host_addr, &dst_host_addr, config->peers->drkey_protocol,
 			ns_now, 0, &drkey);
 	if (res != -2) {
-		printf("Error: ns_now = ns_now + 20*10e9; "
+		printf("Error: ns_now = ns_now + 20*1e9; "
 			   "lf_keymanager_worker_inbound_get_drkey (expected = -2, res = "
 			   "%d)\n",
 				res);
@@ -179,7 +179,7 @@ test1()
 			&dst_host_addr, &src_host_addr, config->peers->drkey_protocol,
 			ns_now, &drkey);
 	if (res != -2) {
-		printf("Error: ns_now = ns_now + 20*10e9; "
+		printf("Error: ns_now = ns_now + 20*1e9; "
 			   "lf_keymanager_worker_outbound_get_drkey (expected = -2, res = "
 			   "%d)\n",
 				res);


### PR DESCRIPTION
The two time conversion constants `LF_TIME_NS_IN_S` and `LF_TIME_NS_IN_MS` were defined incorrectly.

Should be `1e9` instead of `10e9` and `1e6` instead of `10e6`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lightning-filter/36)
<!-- Reviewable:end -->
