### PR TITLE
 keymanager: fix deadlock in telemetry

### DIFF
--- a/src/keymanager.c
+++ b/src/keymanager.c
@@ -554,7 +554,7 @@ handle_dict_stats(const char *cmd __rte_unused, const char *params __rte_unused,
 	rte_tel_data_add_dict_uint(d, "entries_max",
 			rte_hash_max_key_id(tel_ctx->dict));
 
-	rte_spinlock_lock(&tel_ctx->management_lock);
+	rte_spinlock_unlock(&tel_ctx->management_lock);
 
 	return 0;
 }


### PR DESCRIPTION
Fix a bug that results in a deadlock when querying the metrics of the keymanager.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lightning-filter/52)
<!-- Reviewable:end -->
