### PR TITLE
stats: simplify statistics implementation

### DIFF
--- a/src/lib/telemetry/counters.h
+++ b/src/lib/telemetry/counters.h
@@ -5,23 +5,41 @@
 #ifndef LF_TELEMETRY_COUNTERS_H
 #define LF_TELEMETRY_COUNTERS_H
 
-#define LF_TELEMETRY_FIELD_NAME_MAX 64
-
-/**
- * Struct to store a counter's name.
- */
-struct lf_telemetry_field_name {
-	char name[LF_TELEMETRY_FIELD_NAME_MAX];
-};
+#include <rte_telemetry.h>
 
 /**
  * Helper functions to create counters.
  * See the worker counter in statistics on how to use them.
  */
+
+/**
+ * Macro to define all fields of a counter.
+ */
 #define LF_TELEMETRY_FIELD_DECL(TYPE, NAME)  TYPE NAME;
+
+/**
+ * Macro to reset all fields of a counter.
+ */
 #define LF_TELEMETRY_FIELD_RESET(TYPE, NAME) (counter)->NAME = 0;
+
+/**
+ * Macro to declare all fields names of a counter.
+ */
 #define LF_TELEMETRY_FIELD_NAME(TYPE, NAME)  { #NAME },
+
+/**
+ * Macro to add all fields of two counters together.
+ * Expects a, b and res to be pointers to the respective counters.
+ */
 #define LF_TELEMETRY_FIELD_OP_ADD(TYPE, NAME) \
 	(res)->NAME = (a)->NAME + (b)->NAME;
+
+/**
+ * Macro to add all fields of a counter to a telemetry dictionary.
+ * Expects d to be a pointer to the telemetry dictionary and c to be a pointer to
+ * the counter.
+ */
+#define LF_TELEMETRY_FIELD_ADD_DICT(TYPE, NAME) \
+	rte_tel_data_add_dict_uint(d, #NAME, (c)->NAME);
 
 #endif /* LF_TELEMETRY_COUNTERS_H */

--- a/src/lib/telemetry/counters.h
+++ b/src/lib/telemetry/counters.h
@@ -15,7 +15,7 @@
 /**
  * Macro to define all fields of a counter.
  */
-#define LF_TELEMETRY_FIELD_DECL(TYPE, NAME)  TYPE NAME;
+#define LF_TELEMETRY_FIELD_DECL(TYPE, NAME) TYPE NAME;
 
 /**
  * Macro to reset all fields of a counter.
@@ -25,7 +25,7 @@
 /**
  * Macro to declare all fields names of a counter.
  */
-#define LF_TELEMETRY_FIELD_NAME(TYPE, NAME)  { #NAME },
+#define LF_TELEMETRY_FIELD_NAME(TYPE, NAME) { #NAME },
 
 /**
  * Macro to add all fields of two counters together.
@@ -36,8 +36,8 @@
 
 /**
  * Macro to add all fields of a counter to a telemetry dictionary.
- * Expects d to be a pointer to the telemetry dictionary and c to be a pointer to
- * the counter.
+ * Expects d to be a pointer to the telemetry dictionary and c to be a pointer
+ * to the counter.
  */
 #define LF_TELEMETRY_FIELD_ADD_DICT(TYPE, NAME) \
 	rte_tel_data_add_dict_uint(d, #NAME, (c)->NAME);

--- a/src/main.c
+++ b/src/main.c
@@ -510,8 +510,7 @@ main(int argc, char **argv)
 	/*
 	 * Setup Statistics
 	 */
-	res = lf_statistics_init(&statistics, lf_worker_lcore_map, lf_nb_workers,
-			qsv);
+	res = lf_statistics_init(&statistics, lf_worker_lcore_map, lf_nb_workers);
 	if (res < 0) {
 		rte_exit(EXIT_FAILURE, "Unable to initiate statistics\n");
 	}

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -85,8 +85,7 @@ escape_json(const char *in, char *out, int out_len)
 
 void
 add_worker_statistics(struct lf_statistics_worker *res,
-		struct lf_statistics_worker *a,
-		struct lf_statistics_worker *b)
+		struct lf_statistics_worker *a, struct lf_statistics_worker *b)
 {
 	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_OP_ADD)
 }
@@ -98,8 +97,7 @@ reset_worker_statistics(struct lf_statistics_worker *counter)
 }
 
 void
-counter_field_add_dict(struct rte_tel_data *d,
-		struct lf_statistics_worker *c)
+counter_field_add_dict(struct rte_tel_data *d, struct lf_statistics_worker *c)
 {
 	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_ADD_DICT)
 }

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -122,9 +122,6 @@ lf_statistics_close(struct lf_statistics *stats);
  * @param worker_lcores The lcore assignment for the workers, which determines
  * the socket for which memory is allocated.
  * @param nb_workers Number of worker contexts to be created.
- * @param qsv Workers' QS variable for the RCU synchronization. The QS variable
- * can be shared with other services, i.e., other processes call check on it,
- * because the statistics service calls it rarely and can also wait.
  * @return 0 if successful.
  */
 int

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -67,22 +67,17 @@
 	M(uint64_t, outbound_error)         \
 	M(uint64_t, outbound_no_key)
 
-
-struct lf_statistics_worker_counter {
-	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_DECL)
-};
-
 struct lf_statistics_worker {
-	struct lf_statistics_worker_counter counter;
+	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_DECL)
 } __rte_cache_aligned;
 
 struct lf_statistics {
 	struct lf_statistics_worker *worker[LF_MAX_WORKER];
 	uint16_t nb_workers;
-} __rte_cache_aligned;
+};
 
 #define lf_statistics_worker_counter_add(statistics_worker, field, val) \
-	statistics_worker->counter.field += val
+	statistics_worker->field += val
 
 #define lf_statistics_worker_counter_inc(statistics_worker, field) \
 	lf_statistics_worker_counter_add(statistics_worker, field, 1)

--- a/src/worker.c
+++ b/src/worker.c
@@ -274,7 +274,6 @@ lf_worker_rx(struct lf_worker_context *worker,
 	if (nb_rx > 0) {
 		LF_WORKER_LOG_DP(DEBUG, "%u packets received (port %u, queue %u)\n",
 				nb_rx, rx_port_id, rx_queue_id);
-		(void)lf_statistics_worker_add_burst(worker->statistics, nb_rx);
 	}
 
 	/* Apply mirror filter only if mirror exists for the port. */


### PR DESCRIPTION
Each worker thread has its own statistics struct and updates the counters in it independently. The telemetry thread can read the counters from any worker at any time. We assume that updates (to uint64_t) are atomic. Reading the counters should not cause an invalidation of the worker's cache.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lightning-filter/55)
<!-- Reviewable:end -->
