### PR TITLE
stats: track packet check results per ISD-AS and DRKey protocol number

### DIFF
--- a/src/configmanager.c
+++ b/src/configmanager.c
@@ -15,6 +15,7 @@
 #include "lib/log/log.h"
 #include "plugins/plugins.h"
 #include "ratelimiter.h"
+#include "statistics.h"
 
 
 /*
@@ -53,6 +54,9 @@ lf_configmanager_apply_config(struct lf_configmanager *cm,
 	}
 	if (cm->km != NULL) {
 		res |= lf_keymanager_apply_config(cm->km, new_config);
+	}
+	if (cm->stats != NULL) {
+		res |= lf_statistics_apply_config(cm->stats, new_config);
 	}
 	res |= lf_plugins_apply_config(new_config);
 
@@ -98,7 +102,7 @@ lf_configmanager_apply_config_file(struct lf_configmanager *cm,
 int
 lf_configmanager_init(struct lf_configmanager *cm, uint16_t nb_workers,
 		struct rte_rcu_qsbr *qsv, struct lf_keymanager *km,
-		struct lf_ratelimiter *rl)
+		struct lf_ratelimiter *rl, struct lf_statistics *stats)
 {
 	uint16_t worker_id;
 
@@ -120,6 +124,7 @@ lf_configmanager_init(struct lf_configmanager *cm, uint16_t nb_workers,
 
 	cm->km = km;
 	cm->rl = rl;
+	cm->stats = stats;
 
 	return 0;
 }

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -50,6 +50,7 @@ struct lf_configmanager {
 	/* Reference to other services which are notified on config change. */
 	struct lf_keymanager *km;
 	struct lf_ratelimiter *rl;
+	struct lf_statistics *stats;
 };
 
 /**
@@ -58,7 +59,7 @@ struct lf_configmanager {
 int
 lf_configmanager_init(struct lf_configmanager *cm, uint16_t nb_workers,
 		struct rte_rcu_qsbr *qsv, struct lf_keymanager *km,
-		struct lf_ratelimiter *rl);
+		struct lf_ratelimiter *rl, struct lf_statistics *stats);
 
 /**
  * Load new config from json file.

--- a/src/lib/log/log.h
+++ b/src/lib/log/log.h
@@ -60,8 +60,10 @@ void
 lf_print(const char *format, ...);
 
 #define PRIISDAS "%u-%x:%x:%x"
-#define PRIISDAS_VAL(isd_as)                              \
-	((isd_as) >> 48 & 0XFFFF), ((isd_as) >> 32 & 0XFFFF), \
-			((isd_as) >> 16 & 0XFFFF), ((isd_as) >> 0 & 0XFFFF)
+#define PRIISDAS_VAL(isd_as)                         \
+	(unsigned int)((isd_as) >> 48 & 0XFFFF),         \
+			(unsigned int)((isd_as) >> 32 & 0XFFFF), \
+			(unsigned int)((isd_as) >> 16 & 0XFFFF), \
+			(unsigned int)((isd_as) >> 0 & 0XFFFF)
 
 #endif /* LF_LOG_H */

--- a/src/lib/telemetry/counters.h
+++ b/src/lib/telemetry/counters.h
@@ -5,23 +5,41 @@
 #ifndef LF_TELEMETRY_COUNTERS_H
 #define LF_TELEMETRY_COUNTERS_H
 
-#define LF_TELEMETRY_FIELD_NAME_MAX 64
-
-/**
- * Struct to store a counter's name.
- */
-struct lf_telemetry_field_name {
-	char name[LF_TELEMETRY_FIELD_NAME_MAX];
-};
+#include <rte_telemetry.h>
 
 /**
  * Helper functions to create counters.
  * See the worker counter in statistics on how to use them.
  */
+
+/**
+ * Macro to define all fields of a counter.
+ */
 #define LF_TELEMETRY_FIELD_DECL(TYPE, NAME)  TYPE NAME;
+
+/**
+ * Macro to reset all fields of a counter.
+ */
 #define LF_TELEMETRY_FIELD_RESET(TYPE, NAME) (counter)->NAME = 0;
+
+/**
+ * Macro to declare all fields names of a counter.
+ */
 #define LF_TELEMETRY_FIELD_NAME(TYPE, NAME)  { #NAME },
+
+/**
+ * Macro to add all fields of two counters together.
+ * Expects a, b and res to be pointers to the respective counters.
+ */
 #define LF_TELEMETRY_FIELD_OP_ADD(TYPE, NAME) \
 	(res)->NAME = (a)->NAME + (b)->NAME;
+
+/**
+ * Macro to add all fields of a counter to a telemetry dictionary.
+ * Expects d to be a pointer to the telemetry dictionary and c to be a pointer to
+ * the counter.
+ */
+#define LF_TELEMETRY_FIELD_ADD_DICT(TYPE, NAME) \
+	rte_tel_data_add_dict_uint(d, #NAME, (c)->NAME);
 
 #endif /* LF_TELEMETRY_COUNTERS_H */

--- a/src/lib/telemetry/counters.h
+++ b/src/lib/telemetry/counters.h
@@ -15,7 +15,7 @@
 /**
  * Macro to define all fields of a counter.
  */
-#define LF_TELEMETRY_FIELD_DECL(TYPE, NAME)  TYPE NAME;
+#define LF_TELEMETRY_FIELD_DECL(TYPE, NAME) TYPE NAME;
 
 /**
  * Macro to reset all fields of a counter.
@@ -25,7 +25,7 @@
 /**
  * Macro to declare all fields names of a counter.
  */
-#define LF_TELEMETRY_FIELD_NAME(TYPE, NAME)  { #NAME },
+#define LF_TELEMETRY_FIELD_NAME(TYPE, NAME) { #NAME },
 
 /**
  * Macro to add all fields of two counters together.
@@ -36,8 +36,8 @@
 
 /**
  * Macro to add all fields of a counter to a telemetry dictionary.
- * Expects d to be a pointer to the telemetry dictionary and c to be a pointer to
- * the counter.
+ * Expects d to be a pointer to the telemetry dictionary and c to be a pointer
+ * to the counter.
  */
 #define LF_TELEMETRY_FIELD_ADD_DICT(TYPE, NAME) \
 	rte_tel_data_add_dict_uint(d, #NAME, (c)->NAME);

--- a/src/main.c
+++ b/src/main.c
@@ -510,8 +510,7 @@ main(int argc, char **argv)
 	/*
 	 * Setup Statistics
 	 */
-	res = lf_statistics_init(&statistics, lf_worker_lcore_map, lf_nb_workers,
-			qsv);
+	res = lf_statistics_init(&statistics, lf_worker_lcore_map, lf_nb_workers);
 	if (res < 0) {
 		rte_exit(EXIT_FAILURE, "Unable to initiate statistics\n");
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -510,7 +510,8 @@ main(int argc, char **argv)
 	/*
 	 * Setup Statistics
 	 */
-	res = lf_statistics_init(&statistics, lf_worker_lcore_map, lf_nb_workers);
+	res = lf_statistics_init(&statistics, lf_worker_lcore_map, lf_nb_workers,
+			qsv);
 	if (res < 0) {
 		rte_exit(EXIT_FAILURE, "Unable to initiate statistics\n");
 	}
@@ -532,7 +533,7 @@ main(int argc, char **argv)
 	 * Setup Config Manager
 	 */
 	res = lf_configmanager_init(&configmanager, lf_nb_workers, qsv, &keymanager,
-			&ratelimiter);
+			&ratelimiter, &statistics);
 	if (res != 0) {
 		rte_exit(EXIT_FAILURE, "Fail to init config manager.\n");
 	}

--- a/src/ratelimiter.c
+++ b/src/ratelimiter.c
@@ -140,7 +140,6 @@ dictionary_new(uint32_t size)
 
 	if (dic == NULL) {
 		LF_RATELIMITER_LOG(ERR, "Hash creation failed with: %d\n", errno);
-		rte_hash_free(dic);
 		return NULL;
 	}
 
@@ -159,8 +158,8 @@ static void
 dictionary_free(struct rte_hash *dict)
 {
 	uint32_t iterator;
-	struct lf_ratelimiter_dictionary_key *key_ptr;
-	struct lf_ratelimiter_dictionary_data *data;
+	struct lf_ratelimiter_key *key_ptr;
+	struct lf_ratelimiter_data *data;
 
 	for (iterator = 0; rte_hash_iterate(dict, (void *)&key_ptr, (void **)&data,
 							   &iterator) >= 0;) {
@@ -410,6 +409,7 @@ lf_ratelimiter_close(struct lf_ratelimiter *rl)
 		rte_free(rl->workers[i]);
 	}
 
+	// TODO: double free here (see rte_hash_free above)
 	dictionary_free(rl->dict);
 }
 

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -6,6 +6,9 @@
 #include <stdatomic.h>
 
 #include <rte_cycles.h>
+#include <rte_errno.h>
+#include <rte_hash.h>
+#include <rte_jhash.h>
 #include <rte_lcore.h>
 #include <rte_malloc.h>
 #include <rte_rcu_qsbr.h>
@@ -15,6 +18,7 @@
 #include "lf.h"
 #include "lib/log/log.h"
 #include "lib/time/time.h"
+#include "lib/utils/parse.h"
 #include "statistics.h"
 #include "version.h"
 
@@ -23,6 +27,9 @@
  * Each worker has its own statistics counter and updates it independently.
  * The telemetry process can read the statistics counters at any time because
  * we assume that updates (to uint64_t) are atomic.
+ * Hash table updates are protected by the RCU QSBR mechanism and the management
+ * lock, which ensures that no worker and the telemetry process accesses freed
+ * memory.
  */
 
 /**
@@ -30,6 +37,8 @@
  * Format: "Statistics: log message here"
  */
 #define LF_STATISTICS_LOG(level, ...) LF_LOG(level, "Statistics: " __VA_ARGS__)
+
+#define LF_STATISTICS_IA_DICT_INIT_SIZE 1024
 
 struct lf_statistics *telemetry_ctx;
 
@@ -84,22 +93,166 @@ escape_json(const char *in, char *out, int out_len)
 }
 
 void
-add_worker_statistics(struct lf_statistics_worker *res,
-		struct lf_statistics_worker *a, struct lf_statistics_worker *b)
+add_worker_statistics(struct lf_statistics_worker_counter *res,
+		struct lf_statistics_worker_counter *a,
+		struct lf_statistics_worker_counter *b)
 {
 	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_OP_ADD)
 }
 
 void
-reset_worker_statistics(struct lf_statistics_worker *counter)
+reset_worker_statistics(struct lf_statistics_worker_counter *counter)
 {
 	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_RESET)
 }
 
 void
-counter_field_add_dict(struct rte_tel_data *d, struct lf_statistics_worker *c)
+telemetry_add_dict_worker_statistics(struct rte_tel_data *d,
+		struct lf_statistics_worker_counter *c)
 {
 	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_ADD_DICT)
+}
+
+void
+add_ia_statistics(struct lf_statistics_ia_counter *res,
+		struct lf_statistics_ia_counter *a, struct lf_statistics_ia_counter *b)
+{
+	LF_STATISTICS_IA_COUNTER(LF_TELEMETRY_FIELD_OP_ADD)
+}
+
+void
+telemetry_add_dict_ia_statistics(struct rte_tel_data *d,
+		struct lf_statistics_ia_counter *c)
+{
+	LF_STATISTICS_IA_COUNTER(LF_TELEMETRY_FIELD_ADD_DICT)
+}
+
+static int
+handle_ia_stats_list(const char *cmd __rte_unused,
+		const char *params __rte_unused, struct rte_tel_data *d)
+{
+	rte_spinlock_lock(&telemetry_ctx->management_lock);
+
+	rte_tel_data_start_array(d, RTE_TEL_STRING_VAL);
+
+	for (int worker_id = 0; worker_id < telemetry_ctx->nb_workers;
+			worker_id++) {
+		struct lf_statistics_ia_key *key;
+		struct lf_statistics_ia_counter *data;
+		struct rte_hash *dict = telemetry_ctx->worker[worker_id]->ia_dict;
+		for (uint32_t iterator = 0; rte_hash_iterate(dict, (const void **)&key,
+											(void **)&data, &iterator) >= 0;) {
+			char out[1028];
+			sprintf(out, PRIISDAS ", %d",
+					PRIISDAS_VAL(rte_be_to_cpu_64(key->ia)),
+					rte_be_to_cpu_16(key->drkey_protocol));
+			rte_tel_data_add_array_string(d, out);
+		}
+		/*
+		 * We assume that all workers have the same keys in their dictionary.
+		 * So we can break the loop here.
+		 */
+		break;
+	}
+	rte_spinlock_unlock(&telemetry_ctx->management_lock);
+	return 0;
+}
+
+/** TODO
+ * params:
+ * - Null: aggregated over all ISD ASes and DRKey protocols
+ * - "<ISD AS>, <DRKey protocol>": statistics for a specific ISD AS and DRKey
+ * protocol
+ */
+static int
+handle_ia_stats(const char *cmd __rte_unused, const char *p,
+		struct rte_tel_data *d)
+{
+	int res, err = 0;
+	char params[200];
+	char *tokens[2];
+	uint64_t isd_as;
+	uint64_t drkey_protocol;
+	int worker_id;
+	struct lf_statistics_ia_counter total_stats;
+	memset(&total_stats, 0, sizeof(total_stats));
+
+	rte_spinlock_lock(&telemetry_ctx->management_lock);
+	rte_tel_data_start_dict(d);
+	if (p == NULL) {
+		for (worker_id = 0; worker_id < telemetry_ctx->nb_workers;
+				worker_id++) {
+			struct lf_statistics_ia_key *key;
+			struct lf_statistics_ia_counter *data;
+			struct rte_hash *dict = telemetry_ctx->worker[worker_id]->ia_dict;
+			for (uint32_t iterator = 0;
+					rte_hash_iterate(dict, (const void **)&key, (void **)&data,
+							&iterator) >= 0;) {
+				add_ia_statistics(&total_stats, &total_stats, data);
+			}
+		}
+	} else {
+		strcpy(params, p);
+		tokens[0] = strtok(params, ",");
+		if (tokens[0] == NULL) {
+			LF_STATISTICS_LOG(ERR, "unexpected parameter 0 (must contain "
+								   "ISD-AS and DRKey protocol number)\n");
+			err = -1;
+			goto error;
+		}
+		tokens[1] = strtok(NULL, ",");
+		if (tokens[1] == NULL) {
+			LF_STATISTICS_LOG(ERR, "unexpected parameter 1 (must contain "
+								   "ISD-AS and DRKey protocol number)\n");
+			err = -1;
+			goto error;
+		}
+		if (strtok(NULL, ",") != NULL) {
+			LF_STATISTICS_LOG(ERR, "unexpected parameter 2 (must contain "
+								   "ISD-AS and DRKey protocol number)\n");
+			err = -1;
+			goto error;
+		}
+		res = lf_parse_isd_as(tokens[0], &isd_as);
+		if (res != 0) {
+			LF_STATISTICS_LOG(ERR,
+					"unexpected parameter (failed to parse ISD-AS)\n");
+			err = -1;
+			goto error;
+		}
+		res = lf_parse_unum(tokens[1], &drkey_protocol);
+		if (res != 0 || drkey_protocol > UINT16_MAX) {
+			LF_STATISTICS_LOG(ERR, "unexpected parameter (failed to parse "
+								   "DRKey protocol number)\n");
+			err = -1;
+			goto error;
+		}
+		for (worker_id = 0; worker_id < telemetry_ctx->nb_workers;
+				worker_id++) {
+			struct lf_statistics_ia_key key = {
+				.ia = rte_cpu_to_be_64(isd_as),
+				.drkey_protocol = rte_cpu_to_be_16((uint16_t)drkey_protocol),
+			};
+			struct lf_statistics_ia_counter *data;
+			res = rte_hash_lookup_data(
+					telemetry_ctx->worker[worker_id]->ia_dict, &key,
+					(void **)&data);
+			if (res < 0) {
+				LF_STATISTICS_LOG(ERR,
+						"unexpected parameter (not found <ISD-AS>,<DRKey "
+						"Protocol>: " PRIISDAS ",%d)\n",
+						PRIISDAS_VAL(isd_as), drkey_protocol);
+				err = -1;
+				goto error;
+			}
+			add_ia_statistics(&total_stats, &total_stats, data);
+		}
+	}
+	telemetry_add_dict_ia_statistics(d, &total_stats);
+
+error:
+	rte_spinlock_unlock(&telemetry_ctx->management_lock);
+	return err;
 }
 
 static int
@@ -107,7 +260,7 @@ handle_worker_stats(const char *cmd __rte_unused, const char *params,
 		struct rte_tel_data *d)
 {
 	int worker_id;
-	struct lf_statistics_worker total_stats;
+	struct lf_statistics_worker_counter total_stats;
 	memset(&total_stats, 0, sizeof(total_stats));
 
 	rte_tel_data_start_dict(d);
@@ -118,15 +271,15 @@ handle_worker_stats(const char *cmd __rte_unused, const char *params,
 			return -EINVAL;
 		}
 		add_worker_statistics(&total_stats, &total_stats,
-				telemetry_ctx->worker[worker_id]);
+				&telemetry_ctx->worker[worker_id]->counter);
 	} else {
 		for (worker_id = 0; worker_id < telemetry_ctx->nb_workers;
 				++worker_id) {
 			add_worker_statistics(&total_stats, &total_stats,
-					telemetry_ctx->worker[worker_id]);
+					&telemetry_ctx->worker[worker_id]->counter);
 		}
 	}
-	counter_field_add_dict(d, &total_stats);
+	telemetry_add_dict_worker_statistics(d, &total_stats);
 	return 0;
 }
 
@@ -170,21 +323,206 @@ handle_version(const char *cmd __rte_unused, const char *params,
 	return -1;
 }
 
+static struct lf_statistics_ia_counter *
+dictionary_data_new()
+{
+	return rte_zmalloc(NULL, sizeof(struct lf_statistics_ia_counter), 0);
+}
+
+void
+dictionary_data_free(void *p, void *key_data)
+{
+	assert(p == NULL);
+	(void)p;
+	rte_free(key_data);
+}
+
+static struct rte_hash *
+dictionary_new(uint32_t size, uint16_t lcore_id, struct rte_rcu_qsbr *qsv)
+{
+	struct rte_hash *dic;
+	struct rte_hash_parameters params = { 0 };
+	/* rte_hash table name */
+	char name[RTE_HASH_NAMESIZE];
+	/* counter to ensure unique rte_hash table name */
+	static int counter = 0;
+
+	/* DPDK hash table entry must be at least 8 (undocumented) */
+	if (size < 8) {
+		LF_STATISTICS_LOG(ERR,
+				"Hash creation failed because size is smaller than 8\n");
+		return NULL;
+	}
+
+	snprintf(name, sizeof(name), "lf_s_d%d\n", counter);
+	counter += 1;
+
+	params.name = name;
+	/* DPDK hash table entry must be at least 8 (undocumented) */
+	params.entries = size;
+	/* size of key struct */
+	params.key_len = sizeof(struct lf_statistics_ia_key);
+	/* hash function */
+	params.hash_func = rte_jhash;
+	params.hash_func_init_val = 0;
+	/* socket ID for particular worker */
+	params.socket_id = (int)rte_lcore_to_socket_id(lcore_id);
+	/* ensure that insertion always succeeds */
+	params.extra_flag = RTE_HASH_EXTRA_FLAGS_EXT_TABLE;
+	/* Lock Free Read Write
+	 * This is required because the dictionary entries might be changed while a
+	 * worker accesses them
+	 */
+	params.extra_flag |= RTE_HASH_EXTRA_FLAGS_RW_CONCURRENCY_LF;
+
+	dic = rte_hash_create(&params);
+
+	if (dic == NULL) {
+		LF_STATISTICS_LOG(ERR, "Hash creation failed with: %d\n", errno);
+		return NULL;
+	}
+
+	struct rte_hash_rcu_config rcu_conf = {
+		.mode = RTE_HASH_QSBR_MODE_DQ,
+		.free_key_data_func = dictionary_data_free,
+		.v = qsv,
+	};
+
+	if (rte_hash_rcu_qsbr_add(dic, &rcu_conf) != 0) {
+		LF_STATISTICS_LOG(ERR, "Fail to configure RCU for dictionary (%s)\n",
+				rte_strerror(rte_errno));
+		rte_hash_free(dic);
+		return NULL;
+	}
+
+	/* (fstreun) Why is it not strictly smaller?
+	 * key_id starts at 0 and should go up to size - 1!
+	 */
+	assert(rte_hash_max_key_id(dic) >= 0 &&
+			(uint32_t)rte_hash_max_key_id(dic) <= size);
+
+	LF_STATISTICS_LOG(DEBUG, "Created hash table (size = %d).\n", size);
+
+	return dic;
+}
+
+static void
+dictionary_free(struct rte_hash *dict)
+{
+	uint32_t iterator;
+	struct lf_statistics_ia_key *key_ptr;
+	struct lf_statistics_ia_counter *data;
+	for (iterator = 0; rte_hash_iterate(dict, (void *)&key_ptr, (void **)&data,
+							   &iterator) >= 0;) {
+		rte_free(data);
+	}
+	rte_hash_free(dict);
+}
+
+static int
+dictionary_update(struct rte_hash *dict, const struct lf_config *config)
+{
+	int err = 0, res = 0;
+	int key_id;
+	uint32_t iterator;
+	bool is_in_list;
+	struct lf_statistics_ia_key *key_ptr;
+	struct lf_statistics_ia_counter *dictionary_data;
+	struct lf_config_peer *peer;
+
+	/* remove dictionary entries which are not in the config */
+	for (iterator = 0; (key_id = rte_hash_iterate(dict, (void *)&key_ptr,
+								(void **)&dictionary_data, &iterator)) >= 0;) {
+		is_in_list = false;
+		for (peer = config->peers; peer != NULL; peer = peer->next) {
+			if (peer->isd_as == key_ptr->ia &&
+					peer->drkey_protocol == key_ptr->drkey_protocol) {
+				is_in_list = true;
+				break;
+			}
+		}
+
+		if (!is_in_list) {
+			LF_STATISTICS_LOG(DEBUG,
+					"Remove entry for AS " PRIISDAS " DRKey protocol %u\n",
+					PRIISDAS_VAL(rte_be_to_cpu_64(key_ptr->ia)),
+					key_ptr->drkey_protocol);
+			(void)rte_hash_del_key(dict, key_ptr);
+		}
+	}
+
+	/* add dictionary entries according to the config */
+	for (peer = config->peers; peer != NULL; peer = peer->next) {
+		struct lf_statistics_ia_key key;
+		key.ia = peer->isd_as;
+		key.drkey_protocol = peer->drkey_protocol;
+		key_id = rte_hash_lookup_data(dict, &key, (void **)&dictionary_data);
+
+		if (key_id < 0) {
+			/* entry does not exist yet */
+			LF_STATISTICS_LOG(DEBUG,
+					"Add statistics for IA " PRIISDAS
+					" and DRKey protocol %u. \n",
+					PRIISDAS_VAL(rte_be_to_cpu_64(key.ia)),
+					rte_be_to_cpu_16(key.drkey_protocol));
+
+			dictionary_data = dictionary_data_new();
+			if (dictionary_data == NULL) {
+				LF_STATISTICS_LOG(ERR, "Fail to allocate memory for dictionary "
+									   "entry.\n");
+				return key_id;
+			}
+			res = rte_hash_add_key_data(dict, &key, (void *)dictionary_data);
+			if (res != 0) {
+				LF_STATISTICS_LOG(ERR, "Fail to add dictionary entry.\n");
+				rte_free(dictionary_data);
+				err = res;
+			}
+		}
+	}
+	return err;
+}
+
+int
+lf_statistics_apply_config(struct lf_statistics *stats,
+		const struct lf_config *config)
+{
+	int err = 0;
+	int res;
+	uint16_t worker_id;
+
+	rte_spinlock_lock(&stats->management_lock);
+
+	for (worker_id = 0; worker_id < stats->nb_workers; worker_id++) {
+		res = dictionary_update(stats->worker[worker_id]->ia_dict, config);
+		if (res != 0) {
+			err = res;
+		}
+	}
+
+	rte_spinlock_unlock(&stats->management_lock);
+	return err;
+}
+
 void
 lf_statistics_close(struct lf_statistics *stats)
 {
-	uint16_t worker_id;
-
-	for (worker_id = 0; worker_id < stats->nb_workers; ++worker_id) {
-		rte_free(stats->worker[worker_id]);
-	}
-
+	rte_spinlock_lock(&stats->management_lock);
 	telemetry_ctx = NULL;
+
+	for (uint16_t worker_id = 0; worker_id < stats->nb_workers; ++worker_id) {
+		dictionary_free(stats->worker[worker_id]->ia_dict);
+		stats->worker[worker_id]->ia_dict = NULL;
+		rte_free(stats->worker[worker_id]);
+		stats->worker[worker_id] = NULL;
+	}
+	rte_spinlock_unlock(&stats->management_lock);
 }
 
 int
 lf_statistics_init(struct lf_statistics *stats,
-		uint16_t worker_lcores[LF_MAX_WORKER], uint16_t nb_workers)
+		uint16_t worker_lcores[LF_MAX_WORKER], uint16_t nb_workers,
+		struct rte_rcu_qsbr *qsv)
 {
 	int res;
 	uint16_t worker_id;
@@ -201,9 +539,16 @@ lf_statistics_init(struct lf_statistics *stats,
 			LF_STATISTICS_LOG(ERR, "Fail to allocate memory for worker.\n");
 			return -1;
 		}
-
-		reset_worker_statistics(stats->worker[worker_id]);
+		reset_worker_statistics(&stats->worker[worker_id]->counter);
+		stats->worker[worker_id]->ia_dict = dictionary_new(
+				LF_STATISTICS_IA_DICT_INIT_SIZE, worker_lcores[worker_id], qsv);
+		if (stats->worker[worker_id]->ia_dict == NULL) {
+			LF_STATISTICS_LOG(ERR, "Fail to configure dictionary.\n");
+			return -1;
+		}
 	}
+
+	rte_spinlock_init(&stats->management_lock);
 
 	/*
 	 * Setup telemetry
@@ -224,6 +569,23 @@ lf_statistics_init(struct lf_statistics *stats,
 			handle_worker_stats,
 			"Returns worker statistics. Parameters: None (aggregated over all "
 			"workers) or worker ID");
+	if (res != 0) {
+		LF_STATISTICS_LOG(ERR, "Failed to register telemetry: %d\n", res);
+	}
+
+	/* register /ia/stats */
+	res = rte_telemetry_register_cmd(LF_TELEMETRY_PREFIX "/ia/stats",
+			handle_ia_stats, "Returns ISD AS statistics.\n");
+	if (res != 0) {
+		LF_STATISTICS_LOG(ERR, "Failed to register telemetry: %d\n", res);
+	}
+
+	/* register /ia/stats/list */
+	res = rte_telemetry_register_cmd(LF_TELEMETRY_PREFIX "/ia/stats/list",
+			handle_ia_stats_list,
+			"Returns a list of ISD AS and DRKey protocol numbers that are "
+			"being tracked.\n"
+			"The output can be used as parameters for IA stats.");
 	if (res != 0) {
 		LF_STATISTICS_LOG(ERR, "Failed to register telemetry: %d\n", res);
 	}

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -85,8 +85,7 @@ escape_json(const char *in, char *out, int out_len)
 
 void
 add_worker_statistics(struct lf_statistics_worker *res,
-		struct lf_statistics_worker *a,
-		struct lf_statistics_worker *b)
+		struct lf_statistics_worker *a, struct lf_statistics_worker *b)
 {
 	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_OP_ADD)
 }
@@ -98,8 +97,7 @@ reset_worker_statistics(struct lf_statistics_worker *counter)
 }
 
 void
-counter_field_add_dict(struct rte_tel_data *d,
-		struct lf_statistics_worker *c)
+counter_field_add_dict(struct rte_tel_data *d, struct lf_statistics_worker *c)
 {
 	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_ADD_DICT)
 }

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -122,9 +122,6 @@ lf_statistics_close(struct lf_statistics *stats);
  * @param worker_lcores The lcore assignment for the workers, which determines
  * the socket for which memory is allocated.
  * @param nb_workers Number of worker contexts to be created.
- * @param qsv Workers' QS variable for the RCU synchronization. The QS variable
- * can be shared with other services, i.e., other processes call check on it,
- * because the statistics service calls it rarely and can also wait.
  * @return 0 if successful.
  */
 int

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -151,8 +151,8 @@ lf_statistics_get_ia_counter(struct lf_statistics_worker *stats,
 		}                                                                   \
 	} while (0)
 
-#define lf_statistics_ia_counter_inc(stats, worker_id, key, field) \
-	lf_statistics_ia_counter_add(stats, worker_id, key, field, 1)
+#define lf_statistics_ia_counter_inc(stats, isd_as, drkey_protocol, field) \
+	lf_statistics_ia_counter_add(stats, isd_as, drkey_protocol, field, 1)
 
 int
 lf_statistics_apply_config(struct lf_statistics *stats,

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -67,22 +67,17 @@
 	M(uint64_t, outbound_error)         \
 	M(uint64_t, outbound_no_key)
 
-
-struct lf_statistics_worker_counter {
-	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_DECL)
-};
-
 struct lf_statistics_worker {
-	struct lf_statistics_worker_counter counter;
+	LF_STATISTICS_WORKER_COUNTER(LF_TELEMETRY_FIELD_DECL)
 } __rte_cache_aligned;
 
 struct lf_statistics {
 	struct lf_statistics_worker *worker[LF_MAX_WORKER];
 	uint16_t nb_workers;
-} __rte_cache_aligned;
+};
 
 #define lf_statistics_worker_counter_add(statistics_worker, field, val) \
-	statistics_worker->counter.field += val
+	statistics_worker->field += val
 
 #define lf_statistics_worker_counter_inc(statistics_worker, field) \
 	lf_statistics_worker_counter_add(statistics_worker, field, 1)

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -87,6 +87,7 @@ struct lf_statistics_ia_key {
 struct lf_statistics_worker {
 	struct lf_statistics_worker_counter counter;
 	struct rte_hash *ia_dict;
+	struct lf_statistics_ia_counter untracked_ia;
 };
 
 struct lf_statistics {
@@ -135,9 +136,8 @@ lf_statistics_get_ia_counter(struct lf_statistics_worker *stats,
 
 	key_id = rte_hash_lookup_data(stats->ia_dict, &key, (void **)&data);
 	if (key_id < 0) {
-		return NULL;
+		return &stats->untracked_ia;
 	}
-	// TODO: what to do if ia is not tracked? Get dedicated counter?
 	return data;
 }
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -274,7 +274,6 @@ lf_worker_rx(struct lf_worker_context *worker,
 	if (nb_rx > 0) {
 		LF_WORKER_LOG_DP(DEBUG, "%u packets received (port %u, queue %u)\n",
 				nb_rx, rx_port_id, rx_queue_id);
-		(void)lf_statistics_worker_add_burst(worker->statistics, nb_rx);
 	}
 
 	/* Apply mirror filter only if mirror exists for the port. */

--- a/src/worker_ip.c
+++ b/src/worker_ip.c
@@ -114,8 +114,8 @@ handle_inbound_pkt(struct lf_worker_context *worker_context, struct rte_mbuf *m,
 	res = lf_crypto_hash_cmp(exp_hash, lf_hdr->hash);
 	if (likely(res != 0)) {
 		LF_WORKER_LOG_DP(DEBUG, "Packet hash check failed.\n");
-		lf_statistics_worker_counter_inc(worker_context->statistics,
-				invalid_hash);
+		lf_statistics_ia_counter_inc(worker_context->statistics,
+				pkt_data.src_as, pkt_data.drkey_protocol, invalid_hash);
 #if !(LF_WORKER_IGNORE_HASH_CHECK)
 		// LF_CHECK_VALID_MAC_BUT_INVALID_HASH;
 		return LF_PKT_INBOUND_DROP;

--- a/src/worker_scion.c
+++ b/src/worker_scion.c
@@ -456,7 +456,8 @@ compute_pkt_hash(struct lf_worker_context *worker_context, struct rte_mbuf *m,
  */
 static int
 check_pkt_hash(struct lf_worker_context *worker_context, struct rte_mbuf *m,
-		struct parsed_pkt *parsed_pkt, struct parsed_spao *parsed_spao)
+		struct parsed_pkt *parsed_pkt, struct parsed_spao *parsed_spao,
+		struct lf_pkt_data *pkt_data)
 {
 	int res;
 	uint8_t hash[20];
@@ -475,8 +476,8 @@ check_pkt_hash(struct lf_worker_context *worker_context, struct rte_mbuf *m,
 	res = lf_crypto_hash_cmp(hash, parsed_spao->spao_hdr->hash);
 	if (likely(res != 0)) {
 		LF_WORKER_LOG_DP(DEBUG, "Packet hash check failed.\n");
-		lf_statistics_worker_counter_inc(worker_context->statistics,
-				invalid_hash);
+		lf_statistics_ia_counter_inc(worker_context->statistics,
+				pkt_data->src_as, pkt_data->drkey_protocol, invalid_hash);
 	} else {
 		LF_WORKER_LOG_DP(DEBUG, "Packet hash check passed.\n");
 	}
@@ -640,7 +641,7 @@ handle_inbound_pkt_with_lf_hdr(struct lf_worker_context *worker_context,
 	}
 
 	/* Only if all checks are passed, the packet hash is checked. */
-	res = check_pkt_hash(worker_context, m, parsed_pkt, parsed_spao);
+	res = check_pkt_hash(worker_context, m, parsed_pkt, parsed_spao, pkt_data);
 	if (res == 0) {
 		return LF_CHECK_VALID;
 	} else {


### PR DESCRIPTION
LF packet check results are now tracked for each ISD-AS and DRKey protocol that is listed as a peer in the configuration. The metrics are exposed on the telemetry path `lf/ia/stats`. Furthermore, `lf/ia/stats/list` provides a list of all combinations of ISD-AS and DRKey ptorocol numbers that are being tracked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lightning-filter/56)
<!-- Reviewable:end -->
